### PR TITLE
Add basic Undo Redo Commands

### DIFF
--- a/src/main/java/seedu/weme/logic/commands/MemeAddCommand.java
+++ b/src/main/java/seedu/weme/logic/commands/MemeAddCommand.java
@@ -48,6 +48,7 @@ public class MemeAddCommand extends Command {
         }
 
         model.addMeme(toAdd);
+        model.commitMemeBook();
         return new CommandResult(String.format(MESSAGE_SUCCESS, toAdd));
     }
 

--- a/src/main/java/seedu/weme/logic/commands/MemeClearCommand.java
+++ b/src/main/java/seedu/weme/logic/commands/MemeClearCommand.java
@@ -18,6 +18,7 @@ public class MemeClearCommand extends Command {
     public CommandResult execute(Model model) {
         requireNonNull(model);
         model.setMemeBook(new MemeBook());
+        model.commitMemeBook();
         return new CommandResult(MESSAGE_SUCCESS);
     }
 }

--- a/src/main/java/seedu/weme/logic/commands/MemeDeleteCommand.java
+++ b/src/main/java/seedu/weme/logic/commands/MemeDeleteCommand.java
@@ -41,6 +41,7 @@ public class MemeDeleteCommand extends Command {
 
         Meme memeToDelete = lastShownList.get(targetIndex.getZeroBased());
         model.deleteMeme(memeToDelete);
+        model.commitMemeBook();
         return new CommandResult(String.format(MESSAGE_DELETE_MEME_SUCCESS, memeToDelete));
     }
 

--- a/src/main/java/seedu/weme/logic/commands/MemeEditCommand.java
+++ b/src/main/java/seedu/weme/logic/commands/MemeEditCommand.java
@@ -74,6 +74,7 @@ public class MemeEditCommand extends Command {
         }
 
         model.setMeme(memeToEdit, editedMeme);
+        model.commitMemeBook();
         model.updateFilteredMemeList(PREDICATE_SHOW_ALL_MEMES);
         return new CommandResult(String.format(MESSAGE_EDIT_MEME_SUCCESS, editedMeme));
     }

--- a/src/main/java/seedu/weme/logic/commands/RedoCommand.java
+++ b/src/main/java/seedu/weme/logic/commands/RedoCommand.java
@@ -1,0 +1,31 @@
+package seedu.weme.logic.commands;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.weme.model.Model.PREDICATE_SHOW_ALL_MEMES;
+
+import seedu.weme.logic.commands.exceptions.CommandException;
+import seedu.weme.model.Model;
+
+/**
+ * Reverts the {@code model}'s meme book to its previously undone state.
+ */
+public class RedoCommand extends Command {
+
+    public static final String COMMAND_WORD = "redo";
+
+    public static final String MESSAGE_SUCCESS = "Redo success.";
+    public static final String MESSAGE_FAILURE = "No commands to redo.";
+
+    @Override
+    public CommandResult execute(Model model) throws CommandException {
+        requireNonNull(model);
+
+        if (!model.canRedoMemeBook()) {
+            throw new CommandException(MESSAGE_FAILURE);
+        }
+
+        model.redoMemeBook();
+        model.updateFilteredMemeList(PREDICATE_SHOW_ALL_MEMES);
+        return new CommandResult(MESSAGE_SUCCESS);
+    }
+}

--- a/src/main/java/seedu/weme/logic/commands/UndoCommand.java
+++ b/src/main/java/seedu/weme/logic/commands/UndoCommand.java
@@ -1,0 +1,31 @@
+package seedu.weme.logic.commands;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.weme.model.Model.PREDICATE_SHOW_ALL_MEMES;
+
+import seedu.weme.logic.commands.exceptions.CommandException;
+import seedu.weme.model.Model;
+
+/**
+ * Reverts the {@code model}'s meme book to its previous state.
+ */
+public class UndoCommand extends Command {
+
+    public static final String COMMAND_WORD = "undo";
+
+    public static final String MESSAGE_SUCCESS = "Undo success.";
+    public static final String MESSAGE_FAILURE = "No commands to undo.";
+
+    @Override
+    public CommandResult execute(Model model) throws CommandException {
+        requireNonNull(model);
+
+        if (!model.canUndoMemeBook()) {
+            throw new CommandException(MESSAGE_FAILURE);
+        }
+
+        model.undoMemeBook();
+        model.updateFilteredMemeList(PREDICATE_SHOW_ALL_MEMES);
+        return new CommandResult(MESSAGE_SUCCESS);
+    }
+}

--- a/src/main/java/seedu/weme/logic/parser/WemeParser.java
+++ b/src/main/java/seedu/weme/logic/parser/WemeParser.java
@@ -9,7 +9,9 @@ import java.util.regex.Pattern;
 import seedu.weme.logic.commands.Command;
 import seedu.weme.logic.commands.ExitCommand;
 import seedu.weme.logic.commands.HelpCommand;
+import seedu.weme.logic.commands.RedoCommand;
 import seedu.weme.logic.commands.TabCommand;
+import seedu.weme.logic.commands.UndoCommand;
 import seedu.weme.logic.parser.exceptions.ParseException;
 
 /**
@@ -38,6 +40,11 @@ public abstract class WemeParser {
         final String commandWord = matcher.group("commandWord");
         final String arguments = matcher.group("arguments");
         switch (commandWord) {
+        case UndoCommand.COMMAND_WORD:
+            return new UndoCommand();
+
+        case RedoCommand.COMMAND_WORD:
+            return new RedoCommand();
 
         case TabCommand.COMMAND_WORD:
             return new TabCommandParser().parse(arguments);

--- a/src/main/java/seedu/weme/model/Model.java
+++ b/src/main/java/seedu/weme/model/Model.java
@@ -90,4 +90,29 @@ public interface Model {
      * Returns the context of the model.
      */
     SimpleObjectProperty<ModelContext> getContext();
+
+    /**
+     * Returns true if model has a previous state to restore.
+     */
+    boolean canUndoMemeBook();
+
+    /**
+     * Returns true if model has a undone state to restore.
+     */
+    boolean canRedoMemeBook();
+
+    /**
+     * Restores the model's meme book to its previous state.
+     */
+    void undoMemeBook();
+
+    /**
+     * Restores the mode's meme book to its previously undone state.
+     */
+    void redoMemeBook();
+
+    /**
+     * Saves the current meme book state for undo/redo.
+     */
+    void commitMemeBook();
 }

--- a/src/main/java/seedu/weme/model/ModelManager.java
+++ b/src/main/java/seedu/weme/model/ModelManager.java
@@ -20,7 +20,7 @@ import seedu.weme.model.meme.Meme;
 public class ModelManager implements Model {
     private static final Logger logger = LogsCenter.getLogger(ModelManager.class);
 
-    private final MemeBook memeBook;
+    private final VersionedMemeBook versionedMemeBook;
     private final UserPrefs userPrefs;
     private final FilteredList<Meme> filteredMemes;
 
@@ -36,9 +36,9 @@ public class ModelManager implements Model {
 
         logger.fine("Initializing with meme book: " + memeBook + " and user prefs " + userPrefs);
 
-        this.memeBook = new MemeBook(memeBook);
+        versionedMemeBook = new VersionedMemeBook(memeBook);
         this.userPrefs = new UserPrefs(userPrefs);
-        filteredMemes = new FilteredList<>(this.memeBook.getMemeList());
+        filteredMemes = new FilteredList<>(versionedMemeBook.getMemeList());
     }
 
     public ModelManager() {
@@ -84,28 +84,28 @@ public class ModelManager implements Model {
 
     @Override
     public void setMemeBook(ReadOnlyMemeBook memeBook) {
-        this.memeBook.resetData(memeBook);
+        this.versionedMemeBook.resetData(memeBook);
     }
 
     @Override
     public ReadOnlyMemeBook getMemeBook() {
-        return memeBook;
+        return versionedMemeBook;
     }
 
     @Override
     public boolean hasMeme(Meme meme) {
         requireNonNull(meme);
-        return memeBook.hasMeme(meme);
+        return versionedMemeBook.hasMeme(meme);
     }
 
     @Override
     public void deleteMeme(Meme target) {
-        memeBook.removeMeme(target);
+        versionedMemeBook.removeMeme(target);
     }
 
     @Override
     public void addMeme(Meme meme) {
-        memeBook.addMeme(meme);
+        versionedMemeBook.addMeme(meme);
         updateFilteredMemeList(PREDICATE_SHOW_ALL_MEMES);
     }
 
@@ -113,7 +113,7 @@ public class ModelManager implements Model {
     public void setMeme(Meme target, Meme editedMeme) {
         requireAllNonNull(target, editedMeme);
 
-        memeBook.setMeme(target, editedMeme);
+        versionedMemeBook.setMeme(target, editedMeme);
     }
 
     //=========== Filtered Meme List Accessors =============================================================
@@ -139,6 +139,31 @@ public class ModelManager implements Model {
     }
 
     @Override
+    public boolean canUndoMemeBook() {
+        return versionedMemeBook.canUndo();
+    }
+
+    @Override
+    public boolean canRedoMemeBook() {
+        return versionedMemeBook.canRedo();
+    }
+
+    @Override
+    public void undoMemeBook() {
+        versionedMemeBook.undo();
+    }
+
+    @Override
+    public void redoMemeBook() {
+        versionedMemeBook.redo();
+    }
+
+    @Override
+    public void commitMemeBook() {
+        versionedMemeBook.commit();
+    }
+
+    @Override
     public boolean equals(Object obj) {
         // short circuit if same object
         if (obj == this) {
@@ -152,7 +177,7 @@ public class ModelManager implements Model {
 
         // state check
         ModelManager other = (ModelManager) obj;
-        return memeBook.equals(other.memeBook)
+        return versionedMemeBook.equals(other.versionedMemeBook)
                 && userPrefs.equals(other.userPrefs)
                 && filteredMemes.equals(other.filteredMemes)
                 && context.getValue().equals(other.context.getValue());

--- a/src/main/java/seedu/weme/model/VersionedMemeBook.java
+++ b/src/main/java/seedu/weme/model/VersionedMemeBook.java
@@ -1,0 +1,101 @@
+package seedu.weme.model;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * {@code MemeBook} that keeps track of it's previous states.
+ */
+public class VersionedMemeBook extends MemeBook {
+
+    private final List<ReadOnlyMemeBook> versionedMemeBookStates;
+    private int stateIndex = 0;
+
+    public VersionedMemeBook(ReadOnlyMemeBook initialState) {
+        super(initialState);
+
+        versionedMemeBookStates = new ArrayList<>();
+        versionedMemeBookStates.add(new MemeBook(initialState));
+    }
+
+    /**
+     * Returns true if has previous states to undo to.
+     */
+    public boolean canUndo() {
+        return stateIndex > 0;
+    }
+
+    /**
+     * Returns true if has previously undone states to redo to.
+     */
+    public boolean canRedo() {
+        return stateIndex < versionedMemeBookStates.size() - 1;
+    }
+
+    /**
+     * Saves the current state to the end of the state list.
+     * Wipes previously undone states.
+     */
+    public void commit() {
+        versionedMemeBookStates.subList(stateIndex + 1, versionedMemeBookStates.size()).clear();
+        versionedMemeBookStates.add(new MemeBook(this));
+        stateIndex++;
+    }
+
+    /**
+     * Restores the meme book to its previous state.
+     */
+    public void undo() {
+        if (!canUndo()) {
+            throw new NoUndoableStateException();
+        }
+        stateIndex--;
+        resetData(versionedMemeBookStates.get(stateIndex));
+    }
+
+    /**
+     * Restores the meme book to its previously undone state.
+     */
+    public void redo() {
+        if (!canRedo()) {
+            throw new NoRedoableStateException();
+        }
+        stateIndex++;
+        resetData(versionedMemeBookStates.get(stateIndex));
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+
+        if (!(other instanceof VersionedMemeBook)) {
+            return false;
+        }
+
+        VersionedMemeBook otherMemeBook = (VersionedMemeBook) other;
+
+        return super.equals(otherMemeBook)
+                && versionedMemeBookStates.equals(otherMemeBook.versionedMemeBookStates)
+                && stateIndex == otherMemeBook.stateIndex;
+    }
+
+    /**
+     * Thrown when unable to undo.
+     */
+    public static class NoUndoableStateException extends RuntimeException {
+        private NoUndoableStateException() {
+            super("There are no commands to undo.");
+        }
+    }
+
+    /**
+     * Thrown when unable to redo.
+     */
+    public static class NoRedoableStateException extends RuntimeException {
+        private NoRedoableStateException() {
+            super("There are no commands to redo.");
+        }
+    }
+}

--- a/src/test/java/seedu/weme/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/weme/logic/commands/CommandTestUtil.java
@@ -110,4 +110,19 @@ public class CommandTestUtil {
         assertEquals(1, model.getFilteredMemeList().size());
     }
 
+    /**
+     * Deletes
+     */
+    public static void deleteFirstMeme(Model model) {
+        int initialSize = model.getFilteredMemeList().size();
+
+        assertTrue(initialSize > 0);
+
+        Meme firstMeme = model.getFilteredMemeList().get(0);
+        model.deleteMeme(firstMeme);
+        model.commitMemeBook();
+
+        assertTrue(initialSize - 1 == model.getFilteredMemeList().size());
+    }
+
 }

--- a/src/test/java/seedu/weme/logic/commands/MemeAddCommandIntegrationTest.java
+++ b/src/test/java/seedu/weme/logic/commands/MemeAddCommandIntegrationTest.java
@@ -31,6 +31,7 @@ public class MemeAddCommandIntegrationTest {
 
         Model expectedModel = new ModelManager(model.getMemeBook(), new UserPrefs());
         expectedModel.addMeme(validMeme);
+        expectedModel.commitMemeBook();
 
         assertCommandSuccess(new MemeAddCommand(validMeme), model,
                 String.format(MemeAddCommand.MESSAGE_SUCCESS, validMeme), expectedModel);

--- a/src/test/java/seedu/weme/logic/commands/MemeAddCommandTest.java
+++ b/src/test/java/seedu/weme/logic/commands/MemeAddCommandTest.java
@@ -155,6 +155,32 @@ public class MemeAddCommandTest {
         public SimpleObjectProperty<ModelContext> getContext() {
             throw new AssertionError("This method should not be called.");
         }
+
+        @Override
+        public boolean canUndoMemeBook() {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public boolean canRedoMemeBook() {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public void undoMemeBook() {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public void redoMemeBook() {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public void commitMemeBook() {
+            throw new AssertionError("This method should not be called.");
+        }
+
     }
 
     /**
@@ -191,6 +217,11 @@ public class MemeAddCommandTest {
         public void addMeme(Meme meme) {
             requireNonNull(meme);
             memesAdded.add(meme);
+        }
+
+        @Override
+        public void commitMemeBook() {
+            // called by {@code MemeAddCommand#execute()}
         }
 
         @Override

--- a/src/test/java/seedu/weme/logic/commands/MemeClearCommandTest.java
+++ b/src/test/java/seedu/weme/logic/commands/MemeClearCommandTest.java
@@ -16,6 +16,7 @@ public class MemeClearCommandTest {
     public void execute_emptyMemeBook_success() {
         Model model = new ModelManager();
         Model expectedModel = new ModelManager();
+        expectedModel.commitMemeBook();
 
         assertCommandSuccess(new MemeClearCommand(), model, MemeClearCommand.MESSAGE_SUCCESS, expectedModel);
     }
@@ -25,6 +26,7 @@ public class MemeClearCommandTest {
         Model model = new ModelManager(getTypicalMemeBook(), new UserPrefs());
         Model expectedModel = new ModelManager(getTypicalMemeBook(), new UserPrefs());
         expectedModel.setMemeBook(new MemeBook());
+        expectedModel.commitMemeBook();
 
         assertCommandSuccess(new MemeClearCommand(), model, MemeClearCommand.MESSAGE_SUCCESS, expectedModel);
     }

--- a/src/test/java/seedu/weme/logic/commands/MemeDeleteCommandTest.java
+++ b/src/test/java/seedu/weme/logic/commands/MemeDeleteCommandTest.java
@@ -35,6 +35,7 @@ public class MemeDeleteCommandTest {
 
         ModelManager expectedModel = new ModelManager(model.getMemeBook(), new UserPrefs());
         expectedModel.deleteMeme(memeToDelete);
+        expectedModel.commitMemeBook();
 
         assertCommandSuccess(memeDeleteCommand, model, expectedMessage, expectedModel);
     }
@@ -59,6 +60,7 @@ public class MemeDeleteCommandTest {
         Model expectedModel = new ModelManager(model.getMemeBook(), new UserPrefs());
         expectedModel.deleteMeme(memeToDelete);
         showNoMeme(expectedModel);
+        expectedModel.commitMemeBook();
 
         assertCommandSuccess(memeDeleteCommand, model, expectedMessage, expectedModel);
     }

--- a/src/test/java/seedu/weme/logic/commands/MemeEditCommandTest.java
+++ b/src/test/java/seedu/weme/logic/commands/MemeEditCommandTest.java
@@ -45,6 +45,7 @@ public class MemeEditCommandTest {
 
         Model expectedModel = new ModelManager(new MemeBook(model.getMemeBook()), new UserPrefs());
         expectedModel.setMeme(model.getFilteredMemeList().get(0), editedMeme);
+        expectedModel.commitMemeBook();
 
         assertCommandSuccess(memeEditCommand, model, expectedMessage, expectedModel);
     }
@@ -80,6 +81,7 @@ public class MemeEditCommandTest {
         String expectedMessage = String.format(MemeEditCommand.MESSAGE_EDIT_MEME_SUCCESS, editedMeme);
 
         Model expectedModel = new ModelManager(new MemeBook(model.getMemeBook()), new UserPrefs());
+        expectedModel.commitMemeBook();
 
         assertCommandSuccess(memeEditCommand, model, expectedMessage, expectedModel);
     }
@@ -97,6 +99,7 @@ public class MemeEditCommandTest {
 
         Model expectedModel = new ModelManager(new MemeBook(model.getMemeBook()), new UserPrefs());
         expectedModel.setMeme(model.getFilteredMemeList().get(0), editedMeme);
+        expectedModel.commitMemeBook();
 
         assertCommandSuccess(memeEditCommand, model, expectedMessage, expectedModel);
     }

--- a/src/test/java/seedu/weme/logic/commands/RedoCommandTest.java
+++ b/src/test/java/seedu/weme/logic/commands/RedoCommandTest.java
@@ -1,0 +1,45 @@
+package seedu.weme.logic.commands;
+
+import static seedu.weme.logic.commands.CommandTestUtil.assertCommandFailure;
+import static seedu.weme.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static seedu.weme.logic.commands.CommandTestUtil.deleteFirstMeme;
+import static seedu.weme.testutil.TypicalMemes.getTypicalMemeBook;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.weme.model.Model;
+import seedu.weme.model.ModelManager;
+import seedu.weme.model.UserPrefs;
+
+public class RedoCommandTest {
+    private final Model model = new ModelManager(getTypicalMemeBook(), new UserPrefs());
+    private final Model expectedModel = new ModelManager(getTypicalMemeBook(), new UserPrefs());
+
+    @Test
+    public void execute() {
+        deleteFirstMeme(model);
+        deleteFirstMeme(model);
+        model.undoMemeBook();
+        model.undoMemeBook();
+
+        deleteFirstMeme(expectedModel);
+        deleteFirstMeme(expectedModel);
+        expectedModel.undoMemeBook();
+        expectedModel.undoMemeBook();
+
+        RedoCommand redoCommand = new RedoCommand();
+
+        expectedModel.redoMemeBook();
+
+        // multiple redo states
+        assertCommandSuccess(redoCommand, model, RedoCommand.MESSAGE_SUCCESS, expectedModel);
+
+        expectedModel.redoMemeBook();
+
+        // single redo state
+        assertCommandSuccess(redoCommand, model, RedoCommand.MESSAGE_SUCCESS, expectedModel);
+
+        // no redo state
+        assertCommandFailure(redoCommand, model, RedoCommand.MESSAGE_FAILURE);
+    }
+}

--- a/src/test/java/seedu/weme/logic/commands/UndoCommandTest.java
+++ b/src/test/java/seedu/weme/logic/commands/UndoCommandTest.java
@@ -1,0 +1,41 @@
+package seedu.weme.logic.commands;
+
+import static seedu.weme.logic.commands.CommandTestUtil.assertCommandFailure;
+import static seedu.weme.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static seedu.weme.logic.commands.CommandTestUtil.deleteFirstMeme;
+import static seedu.weme.testutil.TypicalMemes.getTypicalMemeBook;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.weme.model.Model;
+import seedu.weme.model.ModelManager;
+import seedu.weme.model.UserPrefs;
+
+public class UndoCommandTest {
+    private final Model model = new ModelManager(getTypicalMemeBook(), new UserPrefs());
+    private final Model expectedModel = new ModelManager(getTypicalMemeBook(), new UserPrefs());
+
+    @Test
+    public void execute() {
+        deleteFirstMeme(model);
+        deleteFirstMeme(model);
+
+        deleteFirstMeme(expectedModel);
+        deleteFirstMeme(expectedModel);
+
+        UndoCommand undoCommand = new UndoCommand();
+
+        expectedModel.undoMemeBook();
+
+        // multiple undo states
+        assertCommandSuccess(undoCommand, model, UndoCommand.MESSAGE_SUCCESS, expectedModel);
+
+        expectedModel.undoMemeBook();
+
+        // single undo states
+        assertCommandSuccess(undoCommand, model, UndoCommand.MESSAGE_SUCCESS, expectedModel);
+
+        // no undo states
+        assertCommandFailure(undoCommand, model, UndoCommand.MESSAGE_FAILURE);
+    }
+}

--- a/src/test/java/seedu/weme/logic/parser/WemeParserTest.java
+++ b/src/test/java/seedu/weme/logic/parser/WemeParserTest.java
@@ -10,12 +10,26 @@ import org.junit.jupiter.api.Test;
 
 import seedu.weme.logic.commands.ExitCommand;
 import seedu.weme.logic.commands.HelpCommand;
+import seedu.weme.logic.commands.RedoCommand;
 import seedu.weme.logic.commands.TabCommand;
+import seedu.weme.logic.commands.UndoCommand;
 import seedu.weme.logic.parser.exceptions.ParseException;
 
 public class WemeParserTest {
 
     private final WemeParser parser = new WemeParserStub();
+
+    @Test
+    public void parseCommand_undo() throws Exception {
+        assertTrue(parser.parseCommand(UndoCommand.COMMAND_WORD) instanceof UndoCommand);
+        assertTrue(parser.parseCommand(UndoCommand.COMMAND_WORD + " 2") instanceof UndoCommand);
+    }
+
+    @Test
+    public void parseCommand_redo() throws Exception {
+        assertTrue(parser.parseCommand(RedoCommand.COMMAND_WORD) instanceof RedoCommand);
+        assertTrue(parser.parseCommand(RedoCommand.COMMAND_WORD + " 2") instanceof RedoCommand);
+    }
 
     @Test
     public void parseCommand_tab() throws Exception {


### PR DESCRIPTION
Undo Redo currently just reverts the meme entries. Support for other
resources (templates) and statistics, along with file deletion will need
to be integrated later.

* [x] Tests (Did not add tests for VersionedMemeBook due to not knowing how the future implementation will be like)

General Implementation:
Use states to keep track of the data in the app.
To manage files, Weme will compare the list of files in its data directories with the paths of the images in its data. It will just delete all files that are not in this intersection. This is to be implemented in the future when AddCommand and DeleteCommand are fixed.

Possible future considerations:
Undo [TIMES]
undo history to see what can be undone redone / Inform user what was undone redone
