### PR TITLE
Change AddCommand Logic

### DIFF
--- a/src/main/java/seedu/weme/MainApp.java
+++ b/src/main/java/seedu/weme/MainApp.java
@@ -155,6 +155,8 @@ public class MainApp extends Application {
             initializedPrefs = new UserPrefs();
         }
 
+        logger.fine("Loaded preferences: " + initializedPrefs);
+
         //Update prefs file in case it was missing to begin with or there are new/unused fields
         try {
             storage.saveUserPrefs(initializedPrefs);

--- a/src/main/java/seedu/weme/MainApp.java
+++ b/src/main/java/seedu/weme/MainApp.java
@@ -56,7 +56,7 @@ public class MainApp extends Application {
 
         UserPrefsStorage userPrefsStorage = new JsonUserPrefsStorage(config.getUserPrefsFilePath());
         UserPrefs userPrefs = initPrefs(userPrefsStorage);
-        MemeBookStorage memeBookStorage = new JsonMemeBookStorage(userPrefs.getMemeBookFilePath());
+        MemeBookStorage memeBookStorage = new JsonMemeBookStorage(userPrefs.getDataFilePath());
         storage = new StorageManager(memeBookStorage, userPrefsStorage);
 
         initLogging(config);

--- a/src/main/java/seedu/weme/commons/util/FileUtil.java
+++ b/src/main/java/seedu/weme/commons/util/FileUtil.java
@@ -5,11 +5,17 @@ import java.nio.file.Files;
 import java.nio.file.InvalidPathException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.Optional;
 
 /**
  * Writes and reads files
  */
 public class FileUtil {
+
+    public static final String MESSAGE_READ_FILE_FAILURE = "Error encountered while reading the file %s";
+    public static final String MESSAGE_COPY_FAILURE_SOURCE_DOES_NOT_EXIST = "Copy failed: source file does not exist";
 
     private static final String CHARSET = "UTF-8";
 
@@ -80,4 +86,53 @@ public class FileUtil {
         Files.write(file, content.getBytes(CHARSET));
     }
 
+    /**
+     * Computes the SHA-1 hash of a file.
+     *
+     * @param file the file to compute
+     * @return the SHA-1 hash of the file
+     */
+    public static String hash(Path file) {
+        try {
+            MessageDigest digest = MessageDigest.getInstance("SHA-1");
+            byte[] content = Files.readAllBytes(file);
+            return StringUtil.byteArrayToHex(digest.digest(content));
+        } catch (NoSuchAlgorithmException e) {
+            e.printStackTrace();
+            throw new RuntimeException();
+        } catch (IOException e) {
+            throw new IllegalArgumentException(String.format(MESSAGE_READ_FILE_FAILURE, file.toString()));
+        }
+    }
+
+    /**
+     * Copies the file from a directory to another directory.
+     *
+     * @param from the source
+     * @param to   the destination
+     * @throws IOException if the copy has
+     */
+    public static void copy(Path from, Path to) throws IOException {
+        if (isFileExists(from)) {
+            createParentDirsOfFile(to);
+            Files.copy(from, to);
+        } else {
+            throw new IOException(MESSAGE_COPY_FAILURE_SOURCE_DOES_NOT_EXIST);
+        }
+    }
+
+    /**
+     * Gets the extension of {@code Path}.
+     *
+     * @param path the {@code Path} to extract the extension from
+     * @return the extension if present, or {@code Optional#empty()} if there is none
+     */
+    public static Optional<String> getExtension(Path path) {
+        String pathString = path.toString();
+        if (pathString.contains(".")) {
+            return Optional.of(pathString.substring(pathString.lastIndexOf(".") + 1));
+        } else {
+            return Optional.empty();
+        }
+    }
 }

--- a/src/main/java/seedu/weme/commons/util/StringUtil.java
+++ b/src/main/java/seedu/weme/commons/util/StringUtil.java
@@ -65,4 +65,17 @@ public class StringUtil {
             return false;
         }
     }
+
+    /**
+     * Converts a byte array into a hex string.
+     * @param byteArray the byte array to convert
+     * @return the converted hex string
+     */
+    public static String byteArrayToHex(byte[] byteArray) {
+        StringBuilder sb = new StringBuilder(byteArray.length * 2);
+        for (byte b : byteArray) {
+            sb.append(String.format("%02x", b));
+        }
+        return sb.toString().toUpperCase();
+    }
 }

--- a/src/main/java/seedu/weme/logic/LogicManager.java
+++ b/src/main/java/seedu/weme/logic/LogicManager.java
@@ -72,7 +72,7 @@ public class LogicManager implements Logic {
 
     @Override
     public Path getMemeBookFilePath() {
-        return model.getMemeBookFilePath();
+        return model.getDataFilePath();
     }
 
     @Override

--- a/src/main/java/seedu/weme/logic/commands/MemeAddCommand.java
+++ b/src/main/java/seedu/weme/logic/commands/MemeAddCommand.java
@@ -5,9 +5,13 @@ import static seedu.weme.logic.parser.CliSyntax.PREFIX_DESCRIPTION;
 import static seedu.weme.logic.parser.CliSyntax.PREFIX_FILEPATH;
 import static seedu.weme.logic.parser.CliSyntax.PREFIX_TAG;
 
+import java.io.IOException;
+import java.nio.file.FileAlreadyExistsException;
+
 import seedu.weme.logic.commands.exceptions.CommandException;
 import seedu.weme.model.Model;
 import seedu.weme.model.meme.Meme;
+import seedu.weme.model.util.MemeUtil;
 
 /**
  * Adds a meme to the meme book.
@@ -28,6 +32,8 @@ public class MemeAddCommand extends Command {
 
     public static final String MESSAGE_SUCCESS = "New meme added: %1$s";
     public static final String MESSAGE_DUPLICATE_MEME = "This meme already exists in weme";
+    public static final String MESSAGE_COPY_FAILURE = "Error encountered while copying the meme to data folder";
+
 
     private final Meme toAdd;
 
@@ -43,13 +49,23 @@ public class MemeAddCommand extends Command {
     public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
 
-        if (model.hasMeme(toAdd)) {
+        // Copy the meme to internal data directory
+        Meme copiedMeme;
+        try {
+            copiedMeme = MemeUtil.copyMeme(toAdd, model.getMemeImagePath());
+        } catch (FileAlreadyExistsException e) {
+            throw new CommandException(MESSAGE_DUPLICATE_MEME);
+        } catch (IOException e) {
+            throw new CommandException(MESSAGE_COPY_FAILURE);
+        }
+
+        if (model.hasMeme(copiedMeme)) {
             throw new CommandException(MESSAGE_DUPLICATE_MEME);
         }
 
-        model.addMeme(toAdd);
+        model.addMeme(copiedMeme);
         model.commitMemeBook();
-        return new CommandResult(String.format(MESSAGE_SUCCESS, toAdd));
+        return new CommandResult(String.format(MESSAGE_SUCCESS, copiedMeme));
     }
 
     @Override

--- a/src/main/java/seedu/weme/model/Model.java
+++ b/src/main/java/seedu/weme/model/Model.java
@@ -36,14 +36,34 @@ public interface Model {
     void setGuiSettings(GuiSettings guiSettings);
 
     /**
-     * Returns the user prefs' meme book file path.
+     * Returns the user prefs' data file path.
      */
-    Path getMemeBookFilePath();
+    Path getDataFilePath();
 
     /**
-     * Sets the user prefs' meme book file path.
+     * Sets the user prefs' data file path.
      */
-    void setMemeBookFilePath(Path memeBookFilePath);
+    void setDataFilePath(Path dataFilePath);
+
+    /**
+     * Returns the user prefs' meme image path.
+     */
+    Path getMemeImagePath();
+
+    /**
+     * Sets the user prefs' meme image path.
+     */
+    void setMemeImagePath(Path memeImagePath);
+
+    /**
+     * Returns the user prefs' template image path.
+     */
+    Path getTemplateImagePath();
+
+    /**
+     * Sets the user prefs' template image path.
+     */
+    void setTemplateImagePath(Path templateImagePath);
 
     /**
      * Replaces meme book data with the data in {@code memeBook}.

--- a/src/main/java/seedu/weme/model/ModelManager.java
+++ b/src/main/java/seedu/weme/model/ModelManager.java
@@ -70,14 +70,36 @@ public class ModelManager implements Model {
     }
 
     @Override
-    public Path getMemeBookFilePath() {
+    public Path getDataFilePath() {
         return userPrefs.getDataFilePath();
     }
 
     @Override
-    public void setMemeBookFilePath(Path memeBookFilePath) {
-        requireNonNull(memeBookFilePath);
-        userPrefs.setDataFilePath(memeBookFilePath);
+    public void setDataFilePath(Path dataFilePath) {
+        requireNonNull(dataFilePath);
+        userPrefs.setDataFilePath(dataFilePath);
+    }
+
+    @Override
+    public Path getMemeImagePath() {
+        return userPrefs.getMemeImagePath();
+    }
+
+    @Override
+    public void setMemeImagePath(Path memeImagePath) {
+        requireNonNull(memeImagePath);
+        userPrefs.setMemeImagePath(memeImagePath);
+    }
+
+    @Override
+    public Path getTemplateImagePath() {
+        return userPrefs.getTemplateImagePath();
+    }
+
+    @Override
+    public void setTemplateImagePath(Path templateImagePath) {
+        requireNonNull(templateImagePath);
+        userPrefs.setTemplateImagePath(templateImagePath);
     }
 
     //=========== MemeBook ================================================================================

--- a/src/main/java/seedu/weme/model/ModelManager.java
+++ b/src/main/java/seedu/weme/model/ModelManager.java
@@ -71,13 +71,13 @@ public class ModelManager implements Model {
 
     @Override
     public Path getMemeBookFilePath() {
-        return userPrefs.getMemeBookFilePath();
+        return userPrefs.getDataFilePath();
     }
 
     @Override
     public void setMemeBookFilePath(Path memeBookFilePath) {
         requireNonNull(memeBookFilePath);
-        userPrefs.setMemeBookFilePath(memeBookFilePath);
+        userPrefs.setDataFilePath(memeBookFilePath);
     }
 
     //=========== MemeBook ================================================================================

--- a/src/main/java/seedu/weme/model/ReadOnlyUserPrefs.java
+++ b/src/main/java/seedu/weme/model/ReadOnlyUserPrefs.java
@@ -11,6 +11,9 @@ public interface ReadOnlyUserPrefs {
 
     GuiSettings getGuiSettings();
 
-    Path getMemeBookFilePath();
+    Path getDataFilePath();
 
+    Path getMemeImagePath();
+
+    Path getTemplateImagePath();
 }

--- a/src/main/java/seedu/weme/model/UserPrefs.java
+++ b/src/main/java/seedu/weme/model/UserPrefs.java
@@ -14,7 +14,9 @@ import seedu.weme.commons.core.GuiSettings;
 public class UserPrefs implements ReadOnlyUserPrefs {
 
     private GuiSettings guiSettings = new GuiSettings();
-    private Path wemeFilePath = Paths.get("data" , "weme.json");
+    private Path dataFilePath = Paths.get("data" , "weme.json");
+    private Path memeImagePath = Paths.get("data", "memes");
+    private Path templateImagePath = Paths.get("data", "templates");
 
     /**
      * Creates a {@code UserPrefs} with default values.
@@ -35,7 +37,9 @@ public class UserPrefs implements ReadOnlyUserPrefs {
     public void resetData(ReadOnlyUserPrefs newUserPrefs) {
         requireNonNull(newUserPrefs);
         setGuiSettings(newUserPrefs.getGuiSettings());
-        setMemeBookFilePath(newUserPrefs.getMemeBookFilePath());
+        setDataFilePath(newUserPrefs.getDataFilePath());
+        setMemeImagePath(newUserPrefs.getMemeImagePath());
+        setTemplateImagePath(newUserPrefs.getTemplateImagePath());
     }
 
     public GuiSettings getGuiSettings() {
@@ -47,13 +51,33 @@ public class UserPrefs implements ReadOnlyUserPrefs {
         this.guiSettings = guiSettings;
     }
 
-    public Path getMemeBookFilePath() {
-        return wemeFilePath;
+    public Path getDataFilePath() {
+        return dataFilePath;
     }
 
-    public void setMemeBookFilePath(Path memeBookFilePath) {
-        requireNonNull(memeBookFilePath);
-        this.wemeFilePath = memeBookFilePath;
+    public void setDataFilePath(Path dataFilePath) {
+        requireNonNull(dataFilePath);
+        this.dataFilePath = dataFilePath;
+    }
+
+    @Override
+    public Path getMemeImagePath() {
+        return memeImagePath;
+    }
+
+    public void setMemeImagePath(Path memeImagePath) {
+        requireNonNull(memeImagePath);
+        this.memeImagePath = memeImagePath;
+    }
+
+    @Override
+    public Path getTemplateImagePath() {
+        return templateImagePath;
+    }
+
+    public void setTemplateImagePath(Path templateImagePath) {
+        requireNonNull(templateImagePath);
+        this.templateImagePath = templateImagePath;
     }
 
     @Override
@@ -68,19 +92,23 @@ public class UserPrefs implements ReadOnlyUserPrefs {
         UserPrefs o = (UserPrefs) other;
 
         return guiSettings.equals(o.guiSettings)
-                && wemeFilePath.equals(o.wemeFilePath);
+                && dataFilePath.equals(o.dataFilePath)
+                && memeImagePath.equals(o.memeImagePath)
+                && templateImagePath.equals(o.templateImagePath);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(guiSettings, wemeFilePath);
+        return Objects.hash(guiSettings, dataFilePath, memeImagePath, templateImagePath);
     }
 
     @Override
     public String toString() {
         StringBuilder sb = new StringBuilder();
         sb.append("Gui Settings : " + guiSettings);
-        sb.append("\nLocal data file location : " + wemeFilePath);
+        sb.append("\nLocal data file location : " + dataFilePath);
+        sb.append("\nMemes image location : " + memeImagePath);
+        sb.append("\nTemplate image location : " + templateImagePath);
         return sb.toString();
     }
 

--- a/src/main/java/seedu/weme/model/util/MemeUtil.java
+++ b/src/main/java/seedu/weme/model/util/MemeUtil.java
@@ -1,0 +1,42 @@
+package seedu.weme.model.util;
+
+import java.io.IOException;
+import java.nio.file.Path;
+
+import seedu.weme.commons.util.FileUtil;
+import seedu.weme.model.meme.ImagePath;
+import seedu.weme.model.meme.Meme;
+
+/**
+ * A utility class for operations related to {@code Meme}.
+ */
+public class MemeUtil {
+
+    /**
+     * Copies the image of {@code toCopy} to {@code ImagePath}, and returns a new {@code Meme} whose {@code ImagePath}
+     * points to that location.
+     *
+     * @param toCopy       the {@code Meme} to copy
+     * @param memeLocation the meme image location
+     * @return a new {@code Meme} with the new {@code ImagePath}.
+     */
+    public static Meme copyMeme(Meme toCopy, Path memeLocation) throws IOException {
+        Path originalPath = toCopy.getFilePath().getFilePath();
+        Path newPath = getNewImagePath(originalPath, memeLocation);
+        FileUtil.copy(originalPath, newPath);
+        return new Meme(new ImagePath(newPath.toString()), toCopy.getDescription(), toCopy.getTags());
+    }
+
+    /**
+     * Generates the Path the meme image should be stored in.
+     *
+     * @param originalPath original Path of the meme
+     * @param memeLocation meme image location specified in user preferences
+     * @return the Path for the meme to be copied to
+     */
+    public static Path getNewImagePath(Path originalPath, Path memeLocation) {
+        String extension = FileUtil.getExtension(originalPath).orElse("");
+        return memeLocation.resolve(FileUtil.hash(originalPath) + "." + extension);
+    }
+
+}

--- a/src/test/data/JsonUserPrefsStorageTest/ExtraValuesUserPref.json
+++ b/src/test/data/JsonUserPrefsStorageTest/ExtraValuesUserPref.json
@@ -9,5 +9,7 @@
       "z" : 99
     }
   },
-  "wemeFilePath" : "weme.json"
+  "dataFilePath" : "data/weme.json",
+  "memeImagePath": "data/memes",
+  "templateImagePath": "data/templates"
 }

--- a/src/test/data/JsonUserPrefsStorageTest/TypicalUserPref.json
+++ b/src/test/data/JsonUserPrefsStorageTest/TypicalUserPref.json
@@ -7,5 +7,7 @@
       "y" : 100
     }
   },
-  "wemeFilePath" : "weme.json"
+  "dataFilePath" : "data/weme.json",
+  "memeImagePath": "data/memes",
+  "templateImagePath": "data/templates"
 }

--- a/src/test/java/seedu/weme/commons/util/FileUtilTest.java
+++ b/src/test/java/seedu/weme/commons/util/FileUtilTest.java
@@ -1,8 +1,12 @@
 package seedu.weme.commons.util;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.weme.testutil.Assert.assertThrows;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
 
 import org.junit.jupiter.api.Test;
 
@@ -20,4 +24,9 @@ public class FileUtilTest {
         assertThrows(NullPointerException.class, () -> FileUtil.isValidPath(null));
     }
 
+    @Test
+    public void hash() {
+        Path meme = Paths.get("src", "test", "data", "memes", "doge_meme.jpg");
+        assertEquals("5E88E068898624CAA37E4DFA50E1E240470EB2F8", FileUtil.hash(meme));
+    }
 }

--- a/src/test/java/seedu/weme/logic/commands/MemeAddCommandIntegrationTest.java
+++ b/src/test/java/seedu/weme/logic/commands/MemeAddCommandIntegrationTest.java
@@ -9,9 +9,11 @@ import org.junit.jupiter.api.Test;
 
 import seedu.weme.model.Model;
 import seedu.weme.model.ModelManager;
-import seedu.weme.model.UserPrefs;
 import seedu.weme.model.meme.Meme;
 import seedu.weme.testutil.MemeBuilder;
+import seedu.weme.testutil.MemeUtil;
+import seedu.weme.testutil.TestUtil;
+import seedu.weme.testutil.UserPrefsBuilder;
 
 /**
  * Contains integration tests (interaction with the Model) for {@code MemeAddCommand}.
@@ -22,25 +24,30 @@ public class MemeAddCommandIntegrationTest {
 
     @BeforeEach
     public void setUp() {
-        model = new ModelManager(getTypicalMemeBook(), new UserPrefs());
+        model = new ModelManager(getTypicalMemeBook(), new UserPrefsBuilder().build());
+        TestUtil.clearSandBoxFolder();
     }
 
     @Test
-    public void execute_newMeme_success() {
+    public void execute_newMeme_success() throws Exception {
         Meme validMeme = new MemeBuilder().build();
 
-        Model expectedModel = new ModelManager(model.getMemeBook(), new UserPrefs());
-        expectedModel.addMeme(validMeme);
+        Model expectedModel = new ModelManager(model.getMemeBook(), model.getUserPrefs());
+        Meme addedMeme = MemeUtil.generateCopiedMeme(validMeme, expectedModel.getMemeImagePath());
+        expectedModel.addMeme(addedMeme);
         expectedModel.commitMemeBook();
 
         assertCommandSuccess(new MemeAddCommand(validMeme), model,
-                String.format(MemeAddCommand.MESSAGE_SUCCESS, validMeme), expectedModel);
+                String.format(MemeAddCommand.MESSAGE_SUCCESS, addedMeme), expectedModel);
     }
 
     @Test
-    public void execute_duplicateMeme_throwsCommandException() {
-        Meme memeInList = model.getMemeBook().getMemeList().get(0);
-        assertCommandFailure(new MemeAddCommand(memeInList), model, MemeAddCommand.MESSAGE_DUPLICATE_MEME);
+    public void execute_duplicateMeme_throwsCommandException() throws Exception {
+        Meme validMeme = new MemeBuilder().build();
+        Meme addedMeme = MemeUtil.generateCopiedMeme(validMeme, model.getMemeImagePath());
+        model.addMeme(addedMeme);
+
+        assertCommandFailure(new MemeAddCommand(validMeme), model, MemeAddCommand.MESSAGE_DUPLICATE_MEME);
     }
 
 }

--- a/src/test/java/seedu/weme/logic/commands/MemeAddCommandTest.java
+++ b/src/test/java/seedu/weme/logic/commands/MemeAddCommandTest.java
@@ -11,6 +11,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.function.Predicate;
 
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import javafx.beans.property.SimpleObjectProperty;
@@ -24,8 +25,16 @@ import seedu.weme.model.ReadOnlyMemeBook;
 import seedu.weme.model.ReadOnlyUserPrefs;
 import seedu.weme.model.meme.Meme;
 import seedu.weme.testutil.MemeBuilder;
+import seedu.weme.testutil.MemeUtil;
+import seedu.weme.testutil.TestUtil;
+import seedu.weme.testutil.UserPrefsBuilder;
 
 public class MemeAddCommandTest {
+
+    @BeforeEach
+    public void setUp() {
+        TestUtil.clearSandBoxFolder();
+    }
 
     @Test
     public void constructor_nullMeme_throwsNullPointerException() {
@@ -37,17 +46,20 @@ public class MemeAddCommandTest {
         ModelStubAcceptingMemeAdded modelStub = new ModelStubAcceptingMemeAdded();
         Meme validMeme = new MemeBuilder().build();
 
+        Meme addedMeme = MemeUtil.generateCopiedMeme(validMeme, modelStub.getMemeImagePath());
         CommandResult commandResult = new MemeAddCommand(validMeme).execute(modelStub);
 
-        assertEquals(String.format(MemeAddCommand.MESSAGE_SUCCESS, validMeme), commandResult.getFeedbackToUser());
-        assertEquals(Arrays.asList(validMeme), modelStub.memesAdded);
+        assertEquals(String.format(MemeAddCommand.MESSAGE_SUCCESS, addedMeme), commandResult.getFeedbackToUser());
+        assertEquals(Arrays.asList(addedMeme), modelStub.memesAdded);
     }
 
     @Test
-    public void execute_duplicateMeme_throwsCommandException() {
+    public void execute_duplicateMeme_throwsCommandException() throws Exception {
         Meme validMeme = new MemeBuilder().build();
         MemeAddCommand memeAddCommand = new MemeAddCommand(validMeme);
-        ModelStub modelStub = new ModelStubWithMeme(validMeme);
+
+        Meme addedMeme = MemeUtil.generateCopiedMeme(validMeme, new ModelStubWithMeme(validMeme).getMemeImagePath());
+        ModelStub modelStub = new ModelStubWithMeme(addedMeme);
 
         assertThrows(CommandException.class,
                 MemeAddCommand.MESSAGE_DUPLICATE_MEME, () -> memeAddCommand.execute(modelStub));
@@ -102,12 +114,32 @@ public class MemeAddCommandTest {
         }
 
         @Override
-        public Path getMemeBookFilePath() {
+        public Path getDataFilePath() {
             throw new AssertionError("This method should not be called.");
         }
 
         @Override
-        public void setMemeBookFilePath(Path memeBookFilePath) {
+        public void setDataFilePath(Path dataFilePath) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public Path getMemeImagePath() {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public void setMemeImagePath(Path memeImagePath) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public Path getTemplateImagePath() {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public void setTemplateImagePath(Path templateImagePath) {
             throw new AssertionError("This method should not be called.");
         }
 
@@ -199,6 +231,12 @@ public class MemeAddCommandTest {
             requireNonNull(meme);
             return this.meme.isSameMeme(meme);
         }
+
+        @Override
+        public Path getMemeImagePath() {
+            return UserPrefsBuilder.DEFAULT_MEME_IMAGE_PATH;
+        }
+
     }
 
     /**
@@ -222,6 +260,10 @@ public class MemeAddCommandTest {
         @Override
         public void commitMemeBook() {
             // called by {@code MemeAddCommand#execute()}
+        }
+
+        public Path getMemeImagePath() {
+            return UserPrefsBuilder.DEFAULT_MEME_IMAGE_PATH;
         }
 
         @Override

--- a/src/test/java/seedu/weme/model/ModelManagerTest.java
+++ b/src/test/java/seedu/weme/model/ModelManagerTest.java
@@ -37,14 +37,14 @@ public class ModelManagerTest {
     @Test
     public void setUserPrefs_validUserPrefs_copiesUserPrefs() {
         UserPrefs userPrefs = new UserPrefs();
-        userPrefs.setMemeBookFilePath(Paths.get("weme/book/file/path"));
+        userPrefs.setDataFilePath(Paths.get("weme/book/file/path"));
         userPrefs.setGuiSettings(new GuiSettings(1, 2, 3, 4));
         modelManager.setUserPrefs(userPrefs);
         assertEquals(userPrefs, modelManager.getUserPrefs());
 
         // Modifying userPrefs should not modify modelManager's userPrefs
         UserPrefs oldUserPrefs = new UserPrefs(userPrefs);
-        userPrefs.setMemeBookFilePath(Paths.get("new/weme/book/file/path"));
+        userPrefs.setDataFilePath(Paths.get("new/weme/book/file/path"));
         assertEquals(oldUserPrefs, modelManager.getUserPrefs());
     }
 
@@ -126,7 +126,7 @@ public class ModelManagerTest {
 
         // different userPrefs -> returns false
         UserPrefs differentUserPrefs = new UserPrefs();
-        differentUserPrefs.setMemeBookFilePath(Paths.get("differentFilePath"));
+        differentUserPrefs.setDataFilePath(Paths.get("differentFilePath"));
         assertFalse(modelManager.equals(new ModelManager(memeBook, differentUserPrefs)));
     }
 }

--- a/src/test/java/seedu/weme/model/ModelManagerTest.java
+++ b/src/test/java/seedu/weme/model/ModelManagerTest.java
@@ -62,14 +62,14 @@ public class ModelManagerTest {
 
     @Test
     public void setMemeBookFilePath_nullPath_throwsNullPointerException() {
-        assertThrows(NullPointerException.class, () -> modelManager.setMemeBookFilePath(null));
+        assertThrows(NullPointerException.class, () -> modelManager.setDataFilePath(null));
     }
 
     @Test
     public void setMemeBookFilePath_validPath_setsMemeBookFilePath() {
         Path path = Paths.get("weme/book/file/path");
-        modelManager.setMemeBookFilePath(path);
-        assertEquals(path, modelManager.getMemeBookFilePath());
+        modelManager.setDataFilePath(path);
+        assertEquals(path, modelManager.getDataFilePath());
     }
 
     @Test

--- a/src/test/java/seedu/weme/model/UserPrefsTest.java
+++ b/src/test/java/seedu/weme/model/UserPrefsTest.java
@@ -13,9 +13,21 @@ public class UserPrefsTest {
     }
 
     @Test
-    public void setMemeBookFilePath_nullPath_throwsNullPointerException() {
+    public void setDataFilePath_nullPath_throwsNullPointerException() {
         UserPrefs userPrefs = new UserPrefs();
-        assertThrows(NullPointerException.class, () -> userPrefs.setMemeBookFilePath(null));
+        assertThrows(NullPointerException.class, () -> userPrefs.setDataFilePath(null));
+    }
+
+    @Test
+    public void setMemeImagePath_nullPath_throwsNullPointerException() {
+        UserPrefs userPrefs = new UserPrefs();
+        assertThrows(NullPointerException.class, () -> userPrefs.setMemeImagePath(null));
+    }
+
+    @Test
+    public void setTemplateImagePath_nullPath_throwsNullPointerException() {
+        UserPrefs userPrefs = new UserPrefs();
+        assertThrows(NullPointerException.class, () -> userPrefs.setTemplateImagePath(null));
     }
 
 }

--- a/src/test/java/seedu/weme/storage/JsonUserPrefsStorageTest.java
+++ b/src/test/java/seedu/weme/storage/JsonUserPrefsStorageTest.java
@@ -73,7 +73,9 @@ public class JsonUserPrefsStorageTest {
     private UserPrefs getTypicalUserPrefs() {
         UserPrefs userPrefs = new UserPrefs();
         userPrefs.setGuiSettings(new GuiSettings(1000, 500, 300, 100));
-        userPrefs.setMemeBookFilePath(Paths.get("weme.json"));
+        userPrefs.setDataFilePath(Paths.get("data", "weme.json"));
+        userPrefs.setMemeImagePath(Paths.get("data", "memes"));
+        userPrefs.setTemplateImagePath(Paths.get("data", "templates"));
         return userPrefs;
     }
 

--- a/src/test/java/seedu/weme/testutil/MemeUtil.java
+++ b/src/test/java/seedu/weme/testutil/MemeUtil.java
@@ -3,7 +3,11 @@ package seedu.weme.testutil;
 import static seedu.weme.logic.parser.CliSyntax.PREFIX_DESCRIPTION;
 import static seedu.weme.logic.parser.CliSyntax.PREFIX_FILEPATH;
 import static seedu.weme.logic.parser.CliSyntax.PREFIX_TAG;
+import static seedu.weme.model.util.MemeUtil.copyMeme;
 
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.Set;
 
 import seedu.weme.logic.commands.MemeAddCommand;
@@ -54,4 +58,19 @@ public class MemeUtil {
         }
         return sb.toString();
     }
+
+    /**
+     * Similar to {@link seedu.weme.model.util.MemeUtil#copyMeme(Meme, Path)}, except this method deletes the copied
+     * image file immediately afterwards.
+     *
+     * @param toCopy       the {@code Meme} to copy
+     * @param memeLocation the meme image location
+     * @return a new {@code Meme} with the new {@code ImagePath}.
+     */
+    public static Meme generateCopiedMeme(Meme toCopy, Path memeLocation) throws IOException {
+        Meme copied = copyMeme(toCopy, memeLocation);
+        Files.delete(copied.getFilePath().getFilePath());
+        return copied;
+    }
+
 }

--- a/src/test/java/seedu/weme/testutil/TestUtil.java
+++ b/src/test/java/seedu/weme/testutil/TestUtil.java
@@ -1,9 +1,12 @@
 package seedu.weme.testutil;
 
+import java.io.File;
 import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.Comparator;
 
 import seedu.weme.commons.core.index.Index;
 import seedu.weme.model.Model;
@@ -30,6 +33,24 @@ public class TestUtil {
             throw new RuntimeException(e);
         }
         return SANDBOX_FOLDER.resolve(fileName);
+    }
+
+    /**
+     * Clears all files and directories in the sandbox folder.
+     */
+    public static void clearSandBoxFolder() {
+        if (!Files.exists(SANDBOX_FOLDER)) {
+            return;
+        }
+
+        try {
+            Files.walk(SANDBOX_FOLDER)
+                .map(Path::toFile)
+                .sorted(Comparator.reverseOrder())
+                .forEach(File::delete);
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
     }
 
     /**

--- a/src/test/java/seedu/weme/testutil/UserPrefsBuilder.java
+++ b/src/test/java/seedu/weme/testutil/UserPrefsBuilder.java
@@ -1,0 +1,99 @@
+package seedu.weme.testutil;
+
+import java.awt.Point;
+import java.nio.file.Path;
+
+import seedu.weme.commons.core.GuiSettings;
+import seedu.weme.model.ReadOnlyUserPrefs;
+import seedu.weme.model.UserPrefs;
+
+/**
+ * A utility class to help with building {@code UserPrefs}.
+ */
+public class UserPrefsBuilder {
+
+    public static final GuiSettings DEFAULT_GUI_SETTINGS = new GuiSettings();
+    public static final Path DEFAULT_DATA_FILE_PATH = TestUtil.getFilePathInSandboxFolder("data/weme.json");
+    public static final Path DEFAULT_MEME_IMAGE_PATH = TestUtil.getFilePathInSandboxFolder("data/memes");
+    public static final Path DEFAULT_TEMPLATE_IMAGE_PATH = TestUtil.getFilePathInSandboxFolder("data/templates");
+
+    private GuiSettings guiSettings;
+    private Path dataFilePath;
+    private Path memeImagePath;
+    private Path templateImagePath;
+
+    public UserPrefsBuilder() {
+        guiSettings = DEFAULT_GUI_SETTINGS;
+        dataFilePath = DEFAULT_DATA_FILE_PATH;
+        memeImagePath = DEFAULT_MEME_IMAGE_PATH;
+        templateImagePath = DEFAULT_TEMPLATE_IMAGE_PATH;
+    }
+
+    /**
+     * Initializes the UserPrefsBuilder with the data of {@code userPrefsToCopy}.
+     */
+    public UserPrefsBuilder(ReadOnlyUserPrefs userPrefsToCopy) {
+        guiSettings = userPrefsToCopy.getGuiSettings();
+        dataFilePath = userPrefsToCopy.getDataFilePath();
+        memeImagePath = userPrefsToCopy.getMemeImagePath();
+        templateImagePath = userPrefsToCopy.getTemplateImagePath();
+    }
+
+    /**
+     * Sets the {@code GuiSettings} of the {@code UserPrefs} that we are building.
+     *
+     * @param guiSettings
+     */
+    public UserPrefsBuilder withGuiSettings(GuiSettings guiSettings) {
+        double width = guiSettings.getWindowWidth();
+        double height = guiSettings.getWindowHeight();
+        Point coordinates = guiSettings.getWindowCoordinates();
+        this.guiSettings = new GuiSettings(width, height, coordinates.x, coordinates.y);
+        return this;
+    }
+
+    /**
+     * Sets the data file path of the {@code UserPrefs} that we are building.
+     *
+     * @param dataFilePath
+     */
+    public UserPrefsBuilder withDataFilePath(Path dataFilePath) {
+        this.dataFilePath = dataFilePath.toFile().toPath();
+        return this;
+    }
+
+    /**
+     * Sets the meme image path of the {@code UserPrefs} that we are building.
+     *
+     * @param memeImagePath
+     */
+    public UserPrefsBuilder withMemeImagePath(Path memeImagePath) {
+        this.memeImagePath = memeImagePath.toFile().toPath();
+        return this;
+    }
+
+    /**
+     * Sets the template image path of the {@code UserPrefs} that we are building.
+     *
+     * @param templateImagePath
+     */
+    public UserPrefsBuilder withTemplateImagePath(Path templateImagePath) {
+        this.templateImagePath = templateImagePath.toFile().toPath();
+        return this;
+    }
+
+    /**
+     * Returns the {@code UserPrefs} that we have built.
+
+     * @return the {@code UserPrefs} that we have built
+     */
+    public UserPrefs build() {
+        UserPrefs ret = new UserPrefs();
+        ret.setGuiSettings(guiSettings);
+        ret.setDataFilePath(dataFilePath);
+        ret.setMemeImagePath(memeImagePath);
+        ret.setTemplateImagePath(templateImagePath);
+        return ret;
+    }
+
+}


### PR DESCRIPTION
Change `AddCommand` logic to copy meme image when creating a meme.

Meme images are copied into an internal data directory upon creation. They will be given a new file name, which is the SHA-1 hash of the image. As such, two memes with the same images will be deemed equal because their hashed filenames are the same.

Meme and template image locations are specified through user preferences. Getters and setters for them are exposed through `Model`.

Files created/edited/deleted in tests are sandboxed in `src/test/data/sandbox` to avoid interference with normal data. All tests that involve file manipulation should call `TestUtil.clearSandbox` before they run.

Closes #58 