### PR TITLE
Refactor ModelContext getters and setters

### DIFF
--- a/src/main/java/seedu/weme/logic/Logic.java
+++ b/src/main/java/seedu/weme/logic/Logic.java
@@ -2,7 +2,7 @@ package seedu.weme.logic;
 
 import java.nio.file.Path;
 
-import javafx.beans.property.SimpleObjectProperty;
+import javafx.beans.value.ObservableValue;
 import javafx.collections.ObservableList;
 import javafx.collections.ObservableMap;
 import seedu.weme.commons.core.GuiSettings;
@@ -41,8 +41,17 @@ public interface Logic {
     /** Returns an unmodifiable view of the filtered list of templates */
     ObservableList<Template> getFilteredTemplateList();
 
-    /** Returns the current context */
-    SimpleObjectProperty<ModelContext> getContext();
+    /**
+     * Returns the current context.
+     */
+    ObservableValue<ModelContext> getContext();
+
+    /**
+     * Sets the context.
+     *
+     * @param context the context to switch to
+     */
+    void setContext(ModelContext context);
 
     /**
      * Returns the user prefs' meme book file path.

--- a/src/main/java/seedu/weme/logic/LogicManager.java
+++ b/src/main/java/seedu/weme/logic/LogicManager.java
@@ -4,7 +4,7 @@ import java.io.IOException;
 import java.nio.file.Path;
 import java.util.logging.Logger;
 
-import javafx.beans.property.SimpleObjectProperty;
+import javafx.beans.value.ObservableValue;
 import javafx.collections.ObservableList;
 import javafx.collections.ObservableMap;
 import seedu.weme.commons.core.GuiSettings;
@@ -60,7 +60,12 @@ public class LogicManager implements Logic {
     }
 
     @Override
-    public SimpleObjectProperty<ModelContext> getContext() {
+    public void setContext(ModelContext context) {
+        model.setContext(context);
+    }
+
+    @Override
+    public ObservableValue<ModelContext> getContext() {
         return model.getContext();
     }
 

--- a/src/main/java/seedu/weme/logic/commands/TabCommand.java
+++ b/src/main/java/seedu/weme/logic/commands/TabCommand.java
@@ -27,7 +27,7 @@ public class TabCommand extends Command {
     @Override
     public CommandResult execute(Model model) {
         requireNonNull(model);
-        model.getContext().setValue(context);
+        model.setContext(context);
         return new CommandResult(String.format(MESSAGE_SUCCESS, context.getContextName()));
     }
 

--- a/src/main/java/seedu/weme/model/Model.java
+++ b/src/main/java/seedu/weme/model/Model.java
@@ -3,7 +3,7 @@ package seedu.weme.model;
 import java.nio.file.Path;
 import java.util.function.Predicate;
 
-import javafx.beans.property.SimpleObjectProperty;
+import javafx.beans.value.ObservableValue;
 import javafx.collections.ObservableList;
 import javafx.collections.ObservableMap;
 import seedu.weme.commons.core.GuiSettings;
@@ -124,9 +124,16 @@ public interface Model {
     void updateFilteredTemplateList(Predicate<Template> predicate);
 
     /**
-     * Returns the context of the model.
+     * Sets the model context.
+     * @param context the context to switch to
      */
-    SimpleObjectProperty<ModelContext> getContext();
+    void setContext(ModelContext context);
+
+    /**
+     * Returns the context of the model.
+     * @return the current context
+     */
+    ObservableValue<ModelContext> getContext();
 
     /**
      * Returns true if model has a previous state to restore.

--- a/src/main/java/seedu/weme/model/ModelManager.java
+++ b/src/main/java/seedu/weme/model/ModelManager.java
@@ -14,6 +14,7 @@ import java.util.function.Predicate;
 import java.util.logging.Logger;
 
 import javafx.beans.property.SimpleObjectProperty;
+import javafx.beans.value.ObservableValue;
 import javafx.collections.ObservableList;
 import javafx.collections.ObservableMap;
 import javafx.collections.transformation.FilteredList;
@@ -182,7 +183,12 @@ public class ModelManager implements Model {
     }
 
     @Override
-    public SimpleObjectProperty<ModelContext> getContext() {
+    public void setContext(ModelContext context) {
+        this.context.setValue(context);
+    }
+
+    @Override
+    public ObservableValue<ModelContext> getContext() {
         return context;
     }
 

--- a/src/test/java/seedu/weme/logic/commands/MemeAddCommandTest.java
+++ b/src/test/java/seedu/weme/logic/commands/MemeAddCommandTest.java
@@ -14,7 +14,7 @@ import java.util.function.Predicate;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import javafx.beans.property.SimpleObjectProperty;
+import javafx.beans.value.ObservableValue;
 import javafx.collections.ObservableList;
 import javafx.collections.ObservableMap;
 import seedu.weme.commons.core.GuiSettings;
@@ -183,7 +183,12 @@ public class MemeAddCommandTest {
         }
 
         @Override
-        public SimpleObjectProperty<ModelContext> getContext() {
+        public void setContext(ModelContext context) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public ObservableValue<ModelContext> getContext() {
             throw new AssertionError("This method should not be called.");
         }
 


### PR DESCRIPTION
1. Refactor original getters to return ObservableValue instead of
   SimpleObjectProperty
2. Provide setter methods to replace calling setValue() on the
   SimpleObjectProperty

Closes #82 