### PR TITLE
Add feedback for Undoable commands

### DIFF
--- a/src/main/java/seedu/weme/logic/commands/exportcommand/UnstageCommand.java
+++ b/src/main/java/seedu/weme/logic/commands/exportcommand/UnstageCommand.java
@@ -47,7 +47,6 @@ public class UnstageCommand extends Command {
 
         Meme memeToUnstage = stagedMemeList.get(targetIndex.getZeroBased());
         model.unstageMeme(memeToUnstage);
-        model.commitWeme();
         return new CommandResult(String.format(MESSAGE_SUCCESS, memeToUnstage));
     }
 

--- a/src/main/java/seedu/weme/logic/commands/generalcommand/RedoCommand.java
+++ b/src/main/java/seedu/weme/logic/commands/generalcommand/RedoCommand.java
@@ -15,7 +15,7 @@ public class RedoCommand extends Command {
 
     public static final String COMMAND_WORD = "redo";
 
-    public static final String MESSAGE_SUCCESS = "Redo success.";
+    public static final String MESSAGE_SUCCESS = "Redid the following command:\n%s";
     public static final String MESSAGE_FAILURE = "No commands to redo.";
 
     @Override
@@ -26,8 +26,8 @@ public class RedoCommand extends Command {
             throw new CommandException(MESSAGE_FAILURE);
         }
 
-        model.redoWeme();
+        String feedback = model.redoWeme();
         model.updateFilteredMemeList(PREDICATE_SHOW_ALL_MEMES);
-        return new CommandResult(MESSAGE_SUCCESS);
+        return new CommandResult(String.format(MESSAGE_SUCCESS, feedback));
     }
 }

--- a/src/main/java/seedu/weme/logic/commands/generalcommand/UndoCommand.java
+++ b/src/main/java/seedu/weme/logic/commands/generalcommand/UndoCommand.java
@@ -15,7 +15,7 @@ public class UndoCommand extends Command {
 
     public static final String COMMAND_WORD = "undo";
 
-    public static final String MESSAGE_SUCCESS = "Undo success.";
+    public static final String MESSAGE_SUCCESS = "Undid the following command:\n%s";
     public static final String MESSAGE_FAILURE = "No commands to undo.";
 
     @Override
@@ -26,8 +26,8 @@ public class UndoCommand extends Command {
             throw new CommandException(MESSAGE_FAILURE);
         }
 
-        model.undoWeme();
+        String feedback = model.undoWeme();
         model.updateFilteredMemeList(PREDICATE_SHOW_ALL_MEMES);
-        return new CommandResult(MESSAGE_SUCCESS);
+        return new CommandResult(String.format(MESSAGE_SUCCESS, feedback));
     }
 }

--- a/src/main/java/seedu/weme/logic/commands/memecommand/MemeAddCommand.java
+++ b/src/main/java/seedu/weme/logic/commands/memecommand/MemeAddCommand.java
@@ -64,8 +64,10 @@ public class MemeAddCommand extends Command {
         }
 
         model.addMeme(copiedMeme);
-        model.commitWeme();
-        return new CommandResult(String.format(MESSAGE_SUCCESS, copiedMeme));
+        CommandResult result = new CommandResult(String.format(MESSAGE_SUCCESS, copiedMeme));
+        model.commitWeme(result.getFeedbackToUser());
+
+        return result;
     }
 
     @Override

--- a/src/main/java/seedu/weme/logic/commands/memecommand/MemeClearCommand.java
+++ b/src/main/java/seedu/weme/logic/commands/memecommand/MemeClearCommand.java
@@ -18,8 +18,11 @@ public class MemeClearCommand extends Command {
     @Override
     public CommandResult execute(Model model) {
         requireNonNull(model);
+
         model.clearMemes();
-        model.commitWeme();
-        return new CommandResult(MESSAGE_SUCCESS);
+        CommandResult result = new CommandResult(MESSAGE_SUCCESS);
+        model.commitWeme(result.getFeedbackToUser());
+
+        return result;
     }
 }

--- a/src/main/java/seedu/weme/logic/commands/memecommand/MemeDeleteCommand.java
+++ b/src/main/java/seedu/weme/logic/commands/memecommand/MemeDeleteCommand.java
@@ -44,8 +44,11 @@ public class MemeDeleteCommand extends Command {
         Meme memeToDelete = lastShownList.get(targetIndex.getZeroBased());
         model.deleteMeme(memeToDelete);
         model.clearMemeStats(memeToDelete);
-        model.commitWeme();
-        return new CommandResult(String.format(MESSAGE_DELETE_MEME_SUCCESS, memeToDelete));
+
+        CommandResult result = new CommandResult(String.format(MESSAGE_DELETE_MEME_SUCCESS, memeToDelete));
+        model.commitWeme(result.getFeedbackToUser());
+
+        return result;
     }
 
     @Override

--- a/src/main/java/seedu/weme/logic/commands/memecommand/MemeEditCommand.java
+++ b/src/main/java/seedu/weme/logic/commands/memecommand/MemeEditCommand.java
@@ -77,9 +77,11 @@ public class MemeEditCommand extends Command {
 
         model.setMeme(memeToEdit, editedMeme);
         model.addMemeToRecord(editedMeme);
-        model.commitWeme();
+        CommandResult result = new CommandResult(String.format(MESSAGE_EDIT_MEME_SUCCESS, editedMeme));
+        model.commitWeme(result.getFeedbackToUser());
         model.updateFilteredMemeList(PREDICATE_SHOW_ALL_MEMES);
-        return new CommandResult(String.format(MESSAGE_EDIT_MEME_SUCCESS, editedMeme));
+
+        return result;
     }
 
     /**

--- a/src/main/java/seedu/weme/logic/commands/memecommand/MemeLikeCommand.java
+++ b/src/main/java/seedu/weme/logic/commands/memecommand/MemeLikeCommand.java
@@ -49,8 +49,11 @@ public class MemeLikeCommand extends Command {
         Meme memeToLike = lastShownList.get(index.getZeroBased());
 
         model.incrementMemeLikeCount(memeToLike);
-        model.commitWeme();
-        return new CommandResult(String.format(MESSAGE_LIKE_MEME_SUCCESS, memeToLike));
+
+        CommandResult result = new CommandResult(String.format(MESSAGE_LIKE_MEME_SUCCESS, memeToLike));
+        model.commitWeme(result.getFeedbackToUser());
+
+        return result;
     }
 
     @Override

--- a/src/main/java/seedu/weme/logic/commands/templatecommand/TemplateAddCommand.java
+++ b/src/main/java/seedu/weme/logic/commands/templatecommand/TemplateAddCommand.java
@@ -60,8 +60,10 @@ public class TemplateAddCommand extends Command {
         }
 
         model.addTemplate(copiedTemplate);
-        model.commitWeme();
-        return new CommandResult(String.format(MESSAGE_SUCCESS, copiedTemplate));
+        CommandResult result = new CommandResult(String.format(MESSAGE_SUCCESS, copiedTemplate));
+        model.commitWeme(result.getFeedbackToUser());
+
+        return result;
     }
 
     @Override

--- a/src/main/java/seedu/weme/logic/commands/templatecommand/TemplateDeleteCommand.java
+++ b/src/main/java/seedu/weme/logic/commands/templatecommand/TemplateDeleteCommand.java
@@ -43,8 +43,10 @@ public class TemplateDeleteCommand extends Command {
 
         Template templateToDelete = lastShownList.get(targetIndex.getZeroBased());
         model.deleteTemplate(templateToDelete);
-        model.commitWeme();
-        return new CommandResult(String.format(MESSAGE_DELETE_TEMPLATE_SUCCESS, templateToDelete));
+        CommandResult result = new CommandResult(String.format(MESSAGE_DELETE_TEMPLATE_SUCCESS, templateToDelete));
+        model.commitWeme(result.getFeedbackToUser());
+
+        return result;
     }
 
     @Override

--- a/src/main/java/seedu/weme/logic/commands/templatecommand/TemplateEditCommand.java
+++ b/src/main/java/seedu/weme/logic/commands/templatecommand/TemplateEditCommand.java
@@ -64,9 +64,11 @@ public class TemplateEditCommand extends Command {
         }
 
         model.setTemplate(templateToEdit, editedTemplate);
-        model.commitWeme();
+        CommandResult result = new CommandResult(String.format(MESSAGE_EDIT_TEMPLATE_SUCCESS, editedTemplate));
+        model.commitWeme(result.getFeedbackToUser());
         model.updateFilteredTemplateList(PREDICATE_SHOW_ALL_TEMPLATES);
-        return new CommandResult(String.format(MESSAGE_EDIT_TEMPLATE_SUCCESS, editedTemplate));
+
+        return result;
     }
 
     @Override

--- a/src/main/java/seedu/weme/model/Model.java
+++ b/src/main/java/seedu/weme/model/Model.java
@@ -225,18 +225,21 @@ public interface Model {
 
     /**
      * Restores the model's Weme to its previous state.
+     * @return the feedback to give the user of the undone command.
      */
-    void undoWeme();
+    String undoWeme();
 
     /**
      * Restores the model's Weme to its previously undone state.
+     * @return the feedback to give the user of the redone command.
      */
-    void redoWeme();
+    String redoWeme();
 
     /**
      * Saves the current Weme state for undo/redo.
+     * @param feedback The string to inform the user what command was undone / redone
      */
-    void commitWeme();
+    void commitWeme(String feedback);
 
     /**
      * Returns statistics data.

--- a/src/main/java/seedu/weme/model/ModelManager.java
+++ b/src/main/java/seedu/weme/model/ModelManager.java
@@ -284,18 +284,18 @@ public class ModelManager implements Model {
     }
 
     @Override
-    public void undoWeme() {
-        versionedWeme.undo();
+    public String undoWeme() {
+        return versionedWeme.undo();
     }
 
     @Override
-    public void redoWeme() {
-        versionedWeme.redo();
+    public String redoWeme() {
+        return versionedWeme.redo();
     }
 
     @Override
-    public void commitWeme() {
-        versionedWeme.commit();
+    public void commitWeme(String feedback) {
+        versionedWeme.commit(feedback);
     }
 
     //=========== Statistics Methods =============================================================

--- a/src/main/java/seedu/weme/model/VersionedWeme.java
+++ b/src/main/java/seedu/weme/model/VersionedWeme.java
@@ -10,6 +10,7 @@ public class VersionedWeme extends Weme {
 
     private final List<ReadOnlyWeme> versionedWemeStates;
     private int stateIndex = 0;
+    private final List<String> feedbackList = new ArrayList<>(); // Feedback for undo redo command
 
     public VersionedWeme(ReadOnlyWeme initialState) {
         super(initialState);
@@ -35,33 +36,40 @@ public class VersionedWeme extends Weme {
     /**
      * Saves the current state to the end of the state list.
      * Wipes previously undone states.
+     * @param feedback the feedback of the last executed command
      */
-    public void commit() {
+    public void commit(String feedback) {
         versionedWemeStates.subList(stateIndex + 1, versionedWemeStates.size()).clear();
+        feedbackList.subList(stateIndex, feedbackList.size()).clear();
         versionedWemeStates.add(new Weme(this));
+        feedbackList.add(feedback);
         stateIndex++;
     }
 
     /**
      * Restores Weme to its previous state.
+     * @return the feedback to the user of the command just undone
      */
-    public void undo() {
+    public String undo() {
         if (!canUndo()) {
             throw new NoUndoableStateException();
         }
         stateIndex--;
         resetData(versionedWemeStates.get(stateIndex));
+        return feedbackList.get(stateIndex);
     }
 
     /**
      * Restores Weme to its previously undone state.
+     * @return the feedback to the user of the command just redone
      */
-    public void redo() {
+    public String redo() {
         if (!canRedo()) {
             throw new NoRedoableStateException();
         }
         stateIndex++;
         resetData(versionedWemeStates.get(stateIndex));
+        return feedbackList.get(stateIndex - 1);
     }
 
     @Override
@@ -78,7 +86,8 @@ public class VersionedWeme extends Weme {
 
         return super.equals(otherWeme)
                 && versionedWemeStates.equals(otherWeme.versionedWemeStates)
-                && stateIndex == otherWeme.stateIndex;
+                && stateIndex == otherWeme.stateIndex
+                && feedbackList.equals(otherWeme.feedbackList);
     }
 
     /**

--- a/src/test/java/seedu/weme/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/weme/logic/commands/CommandTestUtil.java
@@ -2,6 +2,7 @@ package seedu.weme.logic.commands;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.weme.logic.commands.memecommand.MemeDeleteCommand.MESSAGE_DELETE_MEME_SUCCESS;
 import static seedu.weme.logic.parser.util.CliSyntax.PREFIX_DESCRIPTION;
 import static seedu.weme.logic.parser.util.CliSyntax.PREFIX_FILEPATH;
 import static seedu.weme.logic.parser.util.CliSyntax.PREFIX_TAG;
@@ -153,7 +154,8 @@ public class CommandTestUtil {
 
         Meme firstMeme = model.getFilteredMemeList().get(0);
         model.deleteMeme(firstMeme);
-        model.commitWeme();
+        String feedback = String.format(MESSAGE_DELETE_MEME_SUCCESS, firstMeme);
+        model.commitWeme(feedback);
 
         assertTrue(initialSize - 1 == model.getFilteredMemeList().size());
     }

--- a/src/test/java/seedu/weme/logic/commands/generalcommand/RedoCommandTest.java
+++ b/src/test/java/seedu/weme/logic/commands/generalcommand/RedoCommandTest.java
@@ -29,15 +29,15 @@ public class RedoCommandTest {
 
         RedoCommand redoCommand = new RedoCommand();
 
-        expectedModel.redoWeme();
+        String expectedMessage = String.format(RedoCommand.MESSAGE_SUCCESS, expectedModel.redoWeme());
 
         // multiple redo states
-        assertCommandSuccess(redoCommand, model, RedoCommand.MESSAGE_SUCCESS, expectedModel);
+        assertCommandSuccess(redoCommand, model, expectedMessage, expectedModel);
 
-        expectedModel.redoWeme();
+        expectedMessage = String.format(RedoCommand.MESSAGE_SUCCESS, expectedModel.redoWeme());
 
         // single redo state
-        assertCommandSuccess(redoCommand, model, RedoCommand.MESSAGE_SUCCESS, expectedModel);
+        assertCommandSuccess(redoCommand, model, expectedMessage, expectedModel);
 
         // no redo state
         assertCommandFailure(redoCommand, model, RedoCommand.MESSAGE_FAILURE);

--- a/src/test/java/seedu/weme/logic/commands/generalcommand/UndoCommandTest.java
+++ b/src/test/java/seedu/weme/logic/commands/generalcommand/UndoCommandTest.java
@@ -25,15 +25,15 @@ public class UndoCommandTest {
 
         UndoCommand undoCommand = new UndoCommand();
 
-        expectedModel.undoWeme();
+        String expectedMessage = String.format(UndoCommand.MESSAGE_SUCCESS, expectedModel.undoWeme());
 
         // multiple undo states
-        assertCommandSuccess(undoCommand, model, UndoCommand.MESSAGE_SUCCESS, expectedModel);
+        assertCommandSuccess(undoCommand, model, expectedMessage, expectedModel);
 
-        expectedModel.undoWeme();
+        expectedMessage = String.format(UndoCommand.MESSAGE_SUCCESS, expectedModel.undoWeme());
 
         // single undo states
-        assertCommandSuccess(undoCommand, model, UndoCommand.MESSAGE_SUCCESS, expectedModel);
+        assertCommandSuccess(undoCommand, model, expectedMessage, expectedModel);
 
         // no undo states
         assertCommandFailure(undoCommand, model, UndoCommand.MESSAGE_FAILURE);

--- a/src/test/java/seedu/weme/logic/commands/memecommand/MemeAddCommandTest.java
+++ b/src/test/java/seedu/weme/logic/commands/memecommand/MemeAddCommandTest.java
@@ -278,17 +278,17 @@ public class MemeAddCommandTest {
         }
 
         @Override
-        public void undoWeme() {
+        public String undoWeme() {
             throw new AssertionError("This method should not be called.");
         }
 
         @Override
-        public void redoWeme() {
+        public String redoWeme() {
             throw new AssertionError("This method should not be called.");
         }
 
         @Override
-        public void commitWeme() {
+        public void commitWeme(String feedback) {
             throw new AssertionError("This method should not be called.");
         }
 
@@ -411,7 +411,7 @@ public class MemeAddCommandTest {
         }
 
         @Override
-        public void commitWeme() {
+        public void commitWeme(String feedback) {
             // called by {@code MemeAddCommand#execute()}
         }
 

--- a/src/test/java/seedu/weme/logic/commands/memecommand/MemeClearCommandTest.java
+++ b/src/test/java/seedu/weme/logic/commands/memecommand/MemeClearCommandTest.java
@@ -16,7 +16,7 @@ public class MemeClearCommandTest {
     public void execute_emptyWeme_success() {
         Model model = new ModelManager();
         Model expectedModel = new ModelManager();
-        expectedModel.commitWeme();
+        expectedModel.commitWeme(MemeClearCommand.MESSAGE_SUCCESS);
 
         CommandTestUtil.assertCommandSuccess(new MemeClearCommand(), model, MemeClearCommand.MESSAGE_SUCCESS,
                 expectedModel);
@@ -27,7 +27,7 @@ public class MemeClearCommandTest {
         Model model = new ModelManager(getTypicalWeme(), new UserPrefs());
         Model expectedModel = new ModelManager(getTypicalWeme(), new UserPrefs());
         expectedModel.clearMemes();
-        expectedModel.commitWeme();
+        expectedModel.commitWeme(MemeClearCommand.MESSAGE_SUCCESS);
 
         assertCommandSuccess(new MemeClearCommand(), model, MemeClearCommand.MESSAGE_SUCCESS, expectedModel);
     }

--- a/src/test/java/seedu/weme/logic/commands/memecommand/MemeDeleteCommandTest.java
+++ b/src/test/java/seedu/weme/logic/commands/memecommand/MemeDeleteCommandTest.java
@@ -35,7 +35,8 @@ public class MemeDeleteCommandTest {
 
         ModelManager expectedModel = new ModelManager(model.getWeme(), new UserPrefs());
         expectedModel.deleteMeme(memeToDelete);
-        expectedModel.commitWeme();
+        String feedback = String.format(MemeDeleteCommand.MESSAGE_DELETE_MEME_SUCCESS, memeToDelete);
+        expectedModel.commitWeme(expectedMessage);
 
         assertCommandSuccess(memeDeleteCommand, model, expectedMessage, expectedModel);
     }
@@ -60,7 +61,7 @@ public class MemeDeleteCommandTest {
         Model expectedModel = new ModelManager(model.getWeme(), new UserPrefs());
         expectedModel.deleteMeme(memeToDelete);
         showNoMeme(expectedModel);
-        expectedModel.commitWeme();
+        expectedModel.commitWeme(expectedMessage);
 
         assertCommandSuccess(memeDeleteCommand, model, expectedMessage, expectedModel);
     }

--- a/src/test/java/seedu/weme/logic/commands/memecommand/MemeEditCommandTest.java
+++ b/src/test/java/seedu/weme/logic/commands/memecommand/MemeEditCommandTest.java
@@ -45,7 +45,7 @@ public class MemeEditCommandTest {
 
         Model expectedModel = new ModelManager(new Weme(model.getWeme()), new UserPrefs());
         expectedModel.setMeme(model.getFilteredMemeList().get(0), editedMeme);
-        expectedModel.commitWeme();
+        expectedModel.commitWeme(expectedMessage);
 
         assertCommandSuccess(memeEditCommand, model, expectedMessage, expectedModel);
     }
@@ -81,7 +81,7 @@ public class MemeEditCommandTest {
         String expectedMessage = String.format(MemeEditCommand.MESSAGE_EDIT_MEME_SUCCESS, editedMeme);
 
         Model expectedModel = new ModelManager(new Weme(model.getWeme()), new UserPrefs());
-        expectedModel.commitWeme();
+        expectedModel.commitWeme(expectedMessage);
 
         assertCommandSuccess(memeEditCommand, model, expectedMessage, expectedModel);
     }
@@ -99,7 +99,7 @@ public class MemeEditCommandTest {
 
         Model expectedModel = new ModelManager(new Weme(model.getWeme()), new UserPrefs());
         expectedModel.setMeme(model.getFilteredMemeList().get(0), editedMeme);
-        expectedModel.commitWeme();
+        expectedModel.commitWeme(expectedMessage);
 
         assertCommandSuccess(memeEditCommand, model, expectedMessage, expectedModel);
     }


### PR DESCRIPTION
The rationale behind this is to inform users what command they just
undid / redid.

Implementation:
Add feedback in the form of strings to `versionedWeme`. The choice to
use Strings is to prevent coupling. While that makes it more useless for
now, its implementation can be extended to a `Command` or `CommandResult`
in the future if necessary.

Closes #100 