### PR TITLE
Fix extra space in tab bar

### DIFF
--- a/src/main/resources/view/TabBar.fxml
+++ b/src/main/resources/view/TabBar.fxml
@@ -37,7 +37,6 @@
       </children>
     </VBox>
     <Region VBox.vgrow="ALWAYS"/>
-    <Region VBox.vgrow="ALWAYS"/>
     <VBox fx:id="statisticsTab" alignment="CENTER" styleClass="tab" VBox.vgrow="NEVER">
       <padding>
         <Insets top="5" right="5" bottom="5" left="5"/>


### PR DESCRIPTION
Commit 88500d67fbbb7af375728623b1f9c81fdd19870b broke tab bar responsiveness.

Intended:
![image](https://user-images.githubusercontent.com/44059321/67634243-3a940a80-f8f4-11e9-9442-6a076e45922e.png)

After 88500d67fbbb7af375728623b1f9c81fdd19870b:
![image](https://user-images.githubusercontent.com/44059321/67634233-16382e00-f8f4-11e9-942e-d53bbce2dc55.png)

This PR removes the extra `Region` and restores the original tab bar appearance.
