### PR TITLE
Fix undo for Import command

### DIFF
--- a/src/main/java/seedu/weme/logic/Logic.java
+++ b/src/main/java/seedu/weme/logic/Logic.java
@@ -14,7 +14,6 @@ import seedu.weme.logic.prompter.prompt.CommandPrompt;
 import seedu.weme.model.ModelContext;
 import seedu.weme.model.ReadOnlyWeme;
 import seedu.weme.model.meme.Meme;
-import seedu.weme.model.statistics.Stats;
 import seedu.weme.model.template.MemeCreation;
 import seedu.weme.model.template.Template;
 
@@ -94,11 +93,6 @@ public interface Logic {
      * Set the user prefs' GUI settings.
      */
     void setGuiSettings(GuiSettings guiSettings);
-
-    /**
-     * Returns the stats data.
-     */
-    Stats getStats();
 
     /**
      * Returns an unmodifiable view of like data.

--- a/src/main/java/seedu/weme/logic/LogicManager.java
+++ b/src/main/java/seedu/weme/logic/LogicManager.java
@@ -23,7 +23,6 @@ import seedu.weme.model.Model;
 import seedu.weme.model.ModelContext;
 import seedu.weme.model.ReadOnlyWeme;
 import seedu.weme.model.meme.Meme;
-import seedu.weme.model.statistics.Stats;
 import seedu.weme.model.template.MemeCreation;
 import seedu.weme.model.template.Template;
 import seedu.weme.storage.Storage;
@@ -129,11 +128,6 @@ public class LogicManager implements Logic {
     @Override
     public void setGuiSettings(GuiSettings guiSettings) {
         model.setGuiSettings(guiSettings);
-    }
-
-    @Override
-    public Stats getStats() {
-        return model.getStats();
     }
 
     @Override

--- a/src/main/java/seedu/weme/logic/commands/importcommand/ImportCommand.java
+++ b/src/main/java/seedu/weme/logic/commands/importcommand/ImportCommand.java
@@ -31,6 +31,8 @@ public class ImportCommand extends Command {
             throw new CommandException(e.toString());
         }
 
+        model.commitWeme(MESSAGE_SUCCESS);
+
         return new CommandResult(MESSAGE_SUCCESS);
     }
 

--- a/src/main/java/seedu/weme/model/Model.java
+++ b/src/main/java/seedu/weme/model/Model.java
@@ -11,7 +11,6 @@ import javafx.collections.ObservableList;
 import javafx.collections.ObservableMap;
 import seedu.weme.commons.core.GuiSettings;
 import seedu.weme.model.meme.Meme;
-import seedu.weme.model.statistics.Stats;
 import seedu.weme.model.statistics.TagWithCount;
 import seedu.weme.model.tag.Tag;
 import seedu.weme.model.template.MemeCreation;
@@ -260,11 +259,6 @@ public interface Model {
     void commitWeme(String feedback);
 
     /**
-     * Returns statistics data.
-     */
-    Stats getStats();
-
-    /**
      * Returns the number of likes of a meme.
      */
     int getLikesByMeme(Meme meme);
@@ -289,11 +283,6 @@ public interface Model {
      */
     void clearExportList();
 
-
-    /**
-     * Returns past records of command arguments.
-     */
-    Records getRecords();
 
     /**
      * Returns all past records of file paths.

--- a/src/main/java/seedu/weme/model/ModelManager.java
+++ b/src/main/java/seedu/weme/model/ModelManager.java
@@ -23,7 +23,6 @@ import javafx.collections.transformation.FilteredList;
 import seedu.weme.commons.core.GuiSettings;
 import seedu.weme.commons.core.LogsCenter;
 import seedu.weme.model.meme.Meme;
-import seedu.weme.model.statistics.Stats;
 import seedu.weme.model.statistics.TagWithCount;
 import seedu.weme.model.tag.Tag;
 import seedu.weme.model.template.MemeCreation;
@@ -317,11 +316,6 @@ public class ModelManager implements Model {
     //=========== Statistics Methods =============================================================
 
     @Override
-    public Stats getStats() {
-        return versionedWeme.getStats();
-    }
-
-    @Override
     public int getLikesByMeme(Meme meme) {
         return versionedWeme.getLikesByMeme(meme);
     }
@@ -352,11 +346,6 @@ public class ModelManager implements Model {
     }
 
     //=========== Records method ================================================================================
-
-    @Override
-    public Records getRecords() {
-        return versionedWeme.getRecords();
-    }
 
     @Override
     public Set<String> getPathRecords() {

--- a/src/main/java/seedu/weme/model/ReadOnlyWeme.java
+++ b/src/main/java/seedu/weme/model/ReadOnlyWeme.java
@@ -55,8 +55,8 @@ public interface ReadOnlyWeme {
      */
     List<TagWithCount> getTagsWithCountList();
 
-    /** Returns records of Weme.
-     * @return
+    /**
+     * Returns records of Weme.
      */
     Records getRecords();
 

--- a/src/main/java/seedu/weme/model/RecordsManager.java
+++ b/src/main/java/seedu/weme/model/RecordsManager.java
@@ -43,27 +43,27 @@ public class RecordsManager implements Records {
 
     @Override
     public Set<String> getPaths() {
-        return pathRecords;
+        return new HashSet<>(pathRecords);
     }
 
     @Override
     public Set<String> getDescriptions() {
-        return descriptionRecords;
+        return new HashSet<>(descriptionRecords);
     }
 
     @Override
     public Set<String> getTags() {
-        return tagRecords;
+        return new HashSet<>(tagRecords);
     }
 
     @Override
     public Set<String> getNames() {
-        return nameRecords;
+        return new HashSet<>(nameRecords);
     }
 
     @Override
     public void addPath(ImagePath path) {
-        this.pathRecords.add(path.toString());
+        pathRecords.add(path.toString());
     }
 
     @Override
@@ -76,9 +76,7 @@ public class RecordsManager implements Records {
     @Override
     public void addTags(Set<Tag> tags) {
         for (Tag tag: tags) {
-            if (!tag.toString().isEmpty()) {
-                tagRecords.add(tag.getTagName());
-            }
+            tagRecords.add(tag.getTagName());
         }
     }
 
@@ -94,10 +92,10 @@ public class RecordsManager implements Records {
     public void resetRecords(Records records) {
         requireNonNull(records);
 
-        pathRecords = new HashSet<>();
-        descriptionRecords = new HashSet<>();
-        tagRecords = new HashSet<>();
-        nameRecords = new HashSet<>();
+        pathRecords.clear();
+        descriptionRecords.clear();
+        tagRecords.clear();
+        nameRecords.clear();
 
         pathRecords.addAll(records.getPaths());
         descriptionRecords.addAll(records.getDescriptions());

--- a/src/main/java/seedu/weme/model/Weme.java
+++ b/src/main/java/seedu/weme/model/Weme.java
@@ -284,7 +284,7 @@ public class Weme implements ReadOnlyWeme {
 
     @Override
     public Stats getStats() {
-        return stats.getStats();
+        return stats;
     }
 
     public int getLikesByMeme(Meme meme) {

--- a/src/main/java/seedu/weme/model/statistics/Stats.java
+++ b/src/main/java/seedu/weme/model/statistics/Stats.java
@@ -15,8 +15,6 @@ public interface Stats {
 
     void resetData(Stats stats);
 
-    Stats getStats();
-
     //============= Like Data ====================================
 
     int getLikesByMeme(Meme meme);

--- a/src/main/java/seedu/weme/model/statistics/StatsManager.java
+++ b/src/main/java/seedu/weme/model/statistics/StatsManager.java
@@ -97,12 +97,4 @@ public class StatsManager implements Stats {
         setLikeData(newData.getObservableLikeData());
     }
 
-    /**
-     * Returns a copy of the current Stats.
-     */
-    @Override
-    public Stats getStats() {
-        Stats newStats = new StatsManager(this);
-        return newStats;
-    }
 }

--- a/src/test/java/seedu/weme/logic/commands/memecommand/MemeAddCommandTest.java
+++ b/src/test/java/seedu/weme/logic/commands/memecommand/MemeAddCommandTest.java
@@ -25,10 +25,8 @@ import seedu.weme.model.Model;
 import seedu.weme.model.ModelContext;
 import seedu.weme.model.ReadOnlyUserPrefs;
 import seedu.weme.model.ReadOnlyWeme;
-import seedu.weme.model.Records;
 import seedu.weme.model.Weme;
 import seedu.weme.model.meme.Meme;
-import seedu.weme.model.statistics.Stats;
 import seedu.weme.model.statistics.TagWithCount;
 import seedu.weme.model.tag.Tag;
 import seedu.weme.model.template.MemeCreation;
@@ -319,11 +317,6 @@ public class MemeAddCommandTest {
         }
 
         @Override
-        public Stats getStats() {
-            throw new AssertionError("This method should not be called");
-        }
-
-        @Override
         public int getLikesByMeme(Meme meme) {
             throw new AssertionError("This method should not be called");
         }
@@ -350,11 +343,6 @@ public class MemeAddCommandTest {
 
         @Override
         public void clearMemeStats(Meme meme) {
-            throw new AssertionError("This method should not be called");
-        }
-
-        @Override
-        public Records getRecords() {
             throw new AssertionError("This method should not be called");
         }
 


### PR DESCRIPTION
Closes #103 

Decided against support undo redo for Stage, Load and Export for a couple of reasons.
Load requires external files to be present. If they are moved between undo and redo, the app does not reflect it well.
Undoing an export implies that the exported files will be deleted. This is also not possible given the current infrastructure. Will need to revamp undo redo to make this work.
If support for export is not present, support for stage will be awkward. 

For these reasons, I am only supporting undo of the import command, as it introduces new memes to the local state. However, undoing and redoing import will not touch the importList. i.e., after execution of the ImportCommand, the importList will be cleared, and running undo / redo does not change it.

My idea for Undo Redo has changed to just supporting commands that modify the internal data of weme. For now, this only includes Memes, Templates, Records and LikeData in Stats