### PR TITLE
Add archives to Meme and Template contexts

### DIFF
--- a/src/main/java/seedu/weme/logic/commands/generalcommand/RedoCommand.java
+++ b/src/main/java/seedu/weme/logic/commands/generalcommand/RedoCommand.java
@@ -1,7 +1,6 @@
 package seedu.weme.logic.commands.generalcommand;
 
 import static java.util.Objects.requireNonNull;
-import static seedu.weme.model.Model.PREDICATE_SHOW_ALL_MEMES;
 
 import seedu.weme.logic.commands.Command;
 import seedu.weme.logic.commands.CommandResult;
@@ -27,7 +26,6 @@ public class RedoCommand extends Command {
         }
 
         String feedback = model.redoWeme();
-        model.updateFilteredMemeList(PREDICATE_SHOW_ALL_MEMES);
         return new CommandResult(String.format(MESSAGE_SUCCESS, feedback));
     }
 }

--- a/src/main/java/seedu/weme/logic/commands/generalcommand/UndoCommand.java
+++ b/src/main/java/seedu/weme/logic/commands/generalcommand/UndoCommand.java
@@ -1,7 +1,6 @@
 package seedu.weme.logic.commands.generalcommand;
 
 import static java.util.Objects.requireNonNull;
-import static seedu.weme.model.Model.PREDICATE_SHOW_ALL_MEMES;
 
 import seedu.weme.logic.commands.Command;
 import seedu.weme.logic.commands.CommandResult;
@@ -27,7 +26,6 @@ public class UndoCommand extends Command {
         }
 
         String feedback = model.undoWeme();
-        model.updateFilteredMemeList(PREDICATE_SHOW_ALL_MEMES);
         return new CommandResult(String.format(MESSAGE_SUCCESS, feedback));
     }
 }

--- a/src/main/java/seedu/weme/logic/commands/memecommand/MemeArchiveCommand.java
+++ b/src/main/java/seedu/weme/logic/commands/memecommand/MemeArchiveCommand.java
@@ -1,0 +1,76 @@
+package seedu.weme.logic.commands.memecommand;
+
+import static java.util.Objects.requireNonNull;
+
+import java.util.List;
+
+import seedu.weme.commons.core.Messages;
+import seedu.weme.commons.core.index.Index;
+import seedu.weme.logic.commands.Command;
+import seedu.weme.logic.commands.CommandResult;
+import seedu.weme.logic.commands.exceptions.CommandException;
+import seedu.weme.model.Model;
+import seedu.weme.model.meme.Meme;
+
+/**
+ * Likes a meme in the display window.
+ */
+public class MemeArchiveCommand extends Command {
+
+    public static final String COMMAND_WORD = "like";
+
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Like a meme by index."
+            + "Parameters: INDEX (must be a positive integer) "
+            + "Example: " + COMMAND_WORD + " 1 ";
+
+    public static final String MESSAGE_LIKE_MEME_SUCCESS = "Liked Meme: %1$s";
+    public static final String MESSAGE_NOT_LIKED = "Please specify the index of the meme that you like.";
+
+    private final Index index;
+
+    /**
+     * @param index of the meme in the filtered meme list to like
+     */
+    public MemeArchiveCommand(Index index) {
+        requireNonNull(index);
+
+        this.index = index;
+    }
+
+    @Override
+    public CommandResult execute(Model model) throws CommandException {
+        requireNonNull(model);
+        List<Meme> lastShownList = model.getFilteredMemeList();
+
+        if (index.getZeroBased() >= lastShownList.size()) {
+            throw new CommandException(Messages.MESSAGE_INVALID_MEME_DISPLAYED_INDEX);
+        }
+
+        Meme memeToLike = lastShownList.get(index.getZeroBased());
+
+        model.incrementMemeLikeCount(memeToLike);
+
+        CommandResult result = new CommandResult(String.format(MESSAGE_LIKE_MEME_SUCCESS, memeToLike));
+        model.commitWeme(result.getFeedbackToUser());
+
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        // short circuit if same object
+        if (other == this) {
+            return true;
+        }
+
+        // instanceof handles nulls
+        if (!(other instanceof MemeArchiveCommand)) {
+            return false;
+        }
+
+        // state check
+        MemeArchiveCommand e = (MemeArchiveCommand) other;
+        return index.equals(e.index);
+    }
+
+}

--- a/src/main/java/seedu/weme/logic/commands/memecommand/MemeArchiveCommand.java
+++ b/src/main/java/seedu/weme/logic/commands/memecommand/MemeArchiveCommand.java
@@ -18,7 +18,7 @@ import seedu.weme.model.meme.Meme;
 import seedu.weme.model.tag.Tag;
 
 /**
- * Likes a meme in the display window.
+ * Archives a meme in the display window.
  */
 public class MemeArchiveCommand extends Command {
 
@@ -35,7 +35,7 @@ public class MemeArchiveCommand extends Command {
     private final Index index;
 
     /**
-     * @param index of the meme in the filtered meme list to like
+     * @param index of the meme in the filtered meme list to archive
      */
     public MemeArchiveCommand(Index index) {
         requireNonNull(index);

--- a/src/main/java/seedu/weme/logic/commands/memecommand/MemeArchiveCommand.java
+++ b/src/main/java/seedu/weme/logic/commands/memecommand/MemeArchiveCommand.java
@@ -29,7 +29,6 @@ public class MemeArchiveCommand extends Command {
             + "Example: " + COMMAND_WORD + " 1 ";
 
     public static final String MESSAGE_ARCHIVE_MEME_SUCCESS = "Archived Meme: %1$s";
-    public static final String MESSAGE_NOT_ARCHIVED = "Please specify the index of the meme that you want to archive.";
     public static final String MESSAGE_ALREADY_ARCHIVED = "This meme is already archived!";
 
     private final Index index;
@@ -68,6 +67,9 @@ public class MemeArchiveCommand extends Command {
         return result;
     }
 
+    /**
+     * Creates an archived Meme using the input unarchived Meme.
+     */
     private Meme createArchivedMeme(Meme meme) {
         assert meme != null;
 

--- a/src/main/java/seedu/weme/logic/commands/memecommand/MemeArchivesCommand.java
+++ b/src/main/java/seedu/weme/logic/commands/memecommand/MemeArchivesCommand.java
@@ -1,0 +1,25 @@
+package seedu.weme.logic.commands.memecommand;
+
+import static java.util.Objects.requireNonNull;
+
+import seedu.weme.logic.commands.Command;
+import seedu.weme.logic.commands.CommandResult;
+import seedu.weme.model.Model;
+
+/**
+ * Lists all archived memes in Weme to the user.
+ */
+public class MemeArchivesCommand extends Command {
+
+    public static final String COMMAND_WORD = "archives";
+
+    public static final String MESSAGE_SUCCESS = "Listed all archived memes";
+
+
+    @Override
+    public CommandResult execute(Model model) {
+        requireNonNull(model);
+        model.updateFilteredMemeList(meme -> meme.isArchived());
+        return new CommandResult(MESSAGE_SUCCESS);
+    }
+}

--- a/src/main/java/seedu/weme/logic/commands/memecommand/MemeArchivesCommand.java
+++ b/src/main/java/seedu/weme/logic/commands/memecommand/MemeArchivesCommand.java
@@ -1,6 +1,7 @@
 package seedu.weme.logic.commands.memecommand;
 
 import static java.util.Objects.requireNonNull;
+import static seedu.weme.model.Model.PREDICATE_SHOW_ALL_ARCHIVED_MEMES;
 
 import seedu.weme.logic.commands.Command;
 import seedu.weme.logic.commands.CommandResult;
@@ -19,7 +20,7 @@ public class MemeArchivesCommand extends Command {
     @Override
     public CommandResult execute(Model model) {
         requireNonNull(model);
-        model.updateFilteredMemeList(meme -> meme.isArchived());
+        model.updateFilteredMemeList(PREDICATE_SHOW_ALL_ARCHIVED_MEMES);
         return new CommandResult(MESSAGE_SUCCESS);
     }
 }

--- a/src/main/java/seedu/weme/logic/commands/memecommand/MemeEditCommand.java
+++ b/src/main/java/seedu/weme/logic/commands/memecommand/MemeEditCommand.java
@@ -3,7 +3,7 @@ package seedu.weme.logic.commands.memecommand;
 import static java.util.Objects.requireNonNull;
 import static seedu.weme.logic.parser.util.CliSyntax.PREFIX_DESCRIPTION;
 import static seedu.weme.logic.parser.util.CliSyntax.PREFIX_TAG;
-import static seedu.weme.model.Model.PREDICATE_SHOW_ALL_MEMES;
+import static seedu.weme.model.Model.PREDICATE_SHOW_ALL_UNARCHIVED_MEMES;
 
 import java.util.Collections;
 import java.util.HashSet;
@@ -79,7 +79,7 @@ public class MemeEditCommand extends Command {
         model.addMemeToRecord(editedMeme);
         CommandResult result = new CommandResult(String.format(MESSAGE_EDIT_MEME_SUCCESS, editedMeme));
         model.commitWeme(result.getFeedbackToUser());
-        model.updateFilteredMemeList(PREDICATE_SHOW_ALL_MEMES);
+        model.updateFilteredMemeList(PREDICATE_SHOW_ALL_UNARCHIVED_MEMES);
 
         return result;
     }

--- a/src/main/java/seedu/weme/logic/commands/memecommand/MemeEditCommand.java
+++ b/src/main/java/seedu/weme/logic/commands/memecommand/MemeEditCommand.java
@@ -3,7 +3,6 @@ package seedu.weme.logic.commands.memecommand;
 import static java.util.Objects.requireNonNull;
 import static seedu.weme.logic.parser.util.CliSyntax.PREFIX_DESCRIPTION;
 import static seedu.weme.logic.parser.util.CliSyntax.PREFIX_TAG;
-import static seedu.weme.model.Model.PREDICATE_SHOW_ALL_UNARCHIVED_MEMES;
 
 import java.util.Collections;
 import java.util.HashSet;
@@ -79,7 +78,6 @@ public class MemeEditCommand extends Command {
         model.addMemeToRecord(editedMeme);
         CommandResult result = new CommandResult(String.format(MESSAGE_EDIT_MEME_SUCCESS, editedMeme));
         model.commitWeme(result.getFeedbackToUser());
-        model.updateFilteredMemeList(PREDICATE_SHOW_ALL_UNARCHIVED_MEMES);
 
         return result;
     }
@@ -94,8 +92,9 @@ public class MemeEditCommand extends Command {
         ImagePath updatedPath = editMemeDescriptor.getFilePath().orElse(memeToEdit.getImagePath());
         Description updatedDescription = editMemeDescriptor.getDescription().orElse(memeToEdit.getDescription());
         Set<Tag> updatedTags = editMemeDescriptor.getTags().orElse(memeToEdit.getTags());
+        boolean isArchived = memeToEdit.isArchived();
 
-        return new Meme(updatedPath, updatedDescription, updatedTags);
+        return new Meme(updatedPath, updatedDescription, updatedTags, isArchived);
     }
 
     @Override

--- a/src/main/java/seedu/weme/logic/commands/memecommand/MemeListCommand.java
+++ b/src/main/java/seedu/weme/logic/commands/memecommand/MemeListCommand.java
@@ -1,7 +1,7 @@
 package seedu.weme.logic.commands.memecommand;
 
 import static java.util.Objects.requireNonNull;
-import static seedu.weme.model.Model.PREDICATE_SHOW_ALL_MEMES;
+import static seedu.weme.model.Model.PREDICATE_SHOW_ALL_UNARCHIVED_MEMES;
 
 import seedu.weme.logic.commands.Command;
 import seedu.weme.logic.commands.CommandResult;
@@ -20,7 +20,7 @@ public class MemeListCommand extends Command {
     @Override
     public CommandResult execute(Model model) {
         requireNonNull(model);
-        model.updateFilteredMemeList(PREDICATE_SHOW_ALL_MEMES);
+        model.updateFilteredMemeList(PREDICATE_SHOW_ALL_UNARCHIVED_MEMES);
         return new CommandResult(MESSAGE_SUCCESS);
     }
 }

--- a/src/main/java/seedu/weme/logic/commands/memecommand/MemeUnarchiveCommand.java
+++ b/src/main/java/seedu/weme/logic/commands/memecommand/MemeUnarchiveCommand.java
@@ -29,7 +29,6 @@ public class MemeUnarchiveCommand extends Command {
             + "Example: " + COMMAND_WORD + " 1 ";
 
     public static final String MESSAGE_UNARCHIVE_MEME_SUCCESS = "Unarchived Meme: %1$s";
-    public static final String MESSAGE_NOT_UNARCHIVED = "Please specify the index of the meme that you want to unarchive.";
     public static final String MESSAGE_ALREADY_UNARCHIVED = "This meme is already unarchived!";
 
     private final Index index;
@@ -68,6 +67,9 @@ public class MemeUnarchiveCommand extends Command {
         return result;
     }
 
+    /**
+     * Creates an unarchived Meme using the input archived Meme.
+     */
     private Meme createUnarchivedMeme(Meme meme) {
         assert meme != null;
 

--- a/src/main/java/seedu/weme/logic/commands/memecommand/MemeUnarchiveCommand.java
+++ b/src/main/java/seedu/weme/logic/commands/memecommand/MemeUnarchiveCommand.java
@@ -1,7 +1,7 @@
 package seedu.weme.logic.commands.memecommand;
 
 import static java.util.Objects.requireNonNull;
-import static seedu.weme.model.Model.PREDICATE_SHOW_ALL_UNARCHIVED_MEMES;
+import static seedu.weme.model.Model.PREDICATE_SHOW_ALL_ARCHIVED_MEMES;
 
 import java.util.List;
 import java.util.Set;
@@ -20,24 +20,24 @@ import seedu.weme.model.tag.Tag;
 /**
  * Likes a meme in the display window.
  */
-public class MemeArchiveCommand extends Command {
+public class MemeUnarchiveCommand extends Command {
 
-    public static final String COMMAND_WORD = "archive";
+    public static final String COMMAND_WORD = "unarchive";
 
-    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Archive a meme by index."
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Unarchive a meme by index."
             + "Parameters: INDEX (must be a positive integer) "
             + "Example: " + COMMAND_WORD + " 1 ";
 
-    public static final String MESSAGE_ARCHIVE_MEME_SUCCESS = "Archived Meme: %1$s";
-    public static final String MESSAGE_NOT_ARCHIVED = "Please specify the index of the meme that you want to archive.";
-    public static final String MESSAGE_ALREADY_ARCHIVED = "This meme is already archived!";
+    public static final String MESSAGE_UNARCHIVE_MEME_SUCCESS = "Unarchived Meme: %1$s";
+    public static final String MESSAGE_NOT_UNARCHIVED = "Please specify the index of the meme that you want to unarchive.";
+    public static final String MESSAGE_ALREADY_UNARCHIVED = "This meme is already unarchived!";
 
     private final Index index;
 
     /**
      * @param index of the meme in the filtered meme list to like
      */
-    public MemeArchiveCommand(Index index) {
+    public MemeUnarchiveCommand(Index index) {
         requireNonNull(index);
 
         this.index = index;
@@ -52,29 +52,29 @@ public class MemeArchiveCommand extends Command {
             throw new CommandException(Messages.MESSAGE_INVALID_MEME_DISPLAYED_INDEX);
         }
 
-        Meme memeToArchive = lastShownList.get(index.getZeroBased());
+        Meme memeToUnarchive = lastShownList.get(index.getZeroBased());
 
-        if (memeToArchive.isArchived()) {
-            throw new CommandException(MESSAGE_ALREADY_ARCHIVED);
+        if (!memeToUnarchive.isArchived()) {
+            throw new CommandException(MESSAGE_ALREADY_UNARCHIVED);
         }
 
-        Meme archivedMeme = createArchivedMeme(memeToArchive);
+        Meme unarchivedMeme = createUnarchivedMeme(memeToUnarchive);
 
-        model.setMeme(memeToArchive, archivedMeme);
-        CommandResult result = new CommandResult(String.format(MESSAGE_ARCHIVE_MEME_SUCCESS, memeToArchive));
+        model.setMeme(memeToUnarchive, unarchivedMeme);
+        CommandResult result = new CommandResult(String.format(MESSAGE_UNARCHIVE_MEME_SUCCESS, memeToUnarchive));
         model.commitWeme(result.getFeedbackToUser());
-        model.updateFilteredMemeList(PREDICATE_SHOW_ALL_UNARCHIVED_MEMES);
+        model.updateFilteredMemeList(PREDICATE_SHOW_ALL_ARCHIVED_MEMES);
 
         return result;
     }
 
-    private Meme createArchivedMeme(Meme meme) {
+    private Meme createUnarchivedMeme(Meme meme) {
         assert meme != null;
 
         ImagePath imagePath = meme.getImagePath();
         Description description = meme.getDescription();
         Set<Tag> tags = meme.getTags();
-        return new Meme(imagePath, description, tags, true);
+        return new Meme(imagePath, description, tags, false);
     }
 
     @Override
@@ -85,12 +85,12 @@ public class MemeArchiveCommand extends Command {
         }
 
         // instanceof handles nulls
-        if (!(other instanceof MemeArchiveCommand)) {
+        if (!(other instanceof MemeUnarchiveCommand)) {
             return false;
         }
 
         // state check
-        MemeArchiveCommand e = (MemeArchiveCommand) other;
+        MemeUnarchiveCommand e = (MemeUnarchiveCommand) other;
         return index.equals(e.index);
     }
 

--- a/src/main/java/seedu/weme/logic/commands/memecommand/MemeUnarchiveCommand.java
+++ b/src/main/java/seedu/weme/logic/commands/memecommand/MemeUnarchiveCommand.java
@@ -18,7 +18,7 @@ import seedu.weme.model.meme.Meme;
 import seedu.weme.model.tag.Tag;
 
 /**
- * Likes a meme in the display window.
+ * Unarchives a meme in the display window.
  */
 public class MemeUnarchiveCommand extends Command {
 
@@ -35,7 +35,7 @@ public class MemeUnarchiveCommand extends Command {
     private final Index index;
 
     /**
-     * @param index of the meme in the filtered meme list to like
+     * @param index of the meme in the filtered meme list to unarchive
      */
     public MemeUnarchiveCommand(Index index) {
         requireNonNull(index);

--- a/src/main/java/seedu/weme/logic/commands/templatecommand/TemplateArchiveCommand.java
+++ b/src/main/java/seedu/weme/logic/commands/templatecommand/TemplateArchiveCommand.java
@@ -27,7 +27,6 @@ public class TemplateArchiveCommand extends Command {
             + "Example: " + COMMAND_WORD + " 1 ";
 
     public static final String MESSAGE_ARCHIVE_TEMPLATE_SUCCESS = "Archived Template: %1$s";
-    public static final String MESSAGE_NOT_ARCHIVED = "Please specify the index of the template that you want to archive.";
     public static final String MESSAGE_ALREADY_ARCHIVED = "This template is already archived!";
 
     private final Index index;
@@ -66,6 +65,9 @@ public class TemplateArchiveCommand extends Command {
         return result;
     }
 
+    /**
+     * Creates an archived Template using the input unarchived Template.
+     */
     private Template createArchivedTemplate(Template template) {
         assert template != null;
 

--- a/src/main/java/seedu/weme/logic/commands/templatecommand/TemplateArchiveCommand.java
+++ b/src/main/java/seedu/weme/logic/commands/templatecommand/TemplateArchiveCommand.java
@@ -1,0 +1,94 @@
+package seedu.weme.logic.commands.templatecommand;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.weme.model.Model.PREDICATE_SHOW_ALL_UNARCHIVED_TEMPLATES;
+
+import java.util.List;
+
+import seedu.weme.commons.core.Messages;
+import seedu.weme.commons.core.index.Index;
+import seedu.weme.logic.commands.Command;
+import seedu.weme.logic.commands.CommandResult;
+import seedu.weme.logic.commands.exceptions.CommandException;
+import seedu.weme.model.Model;
+import seedu.weme.model.imagePath.ImagePath;
+import seedu.weme.model.template.Name;
+import seedu.weme.model.template.Template;
+
+/**
+ * Archives a template in the display window.
+ */
+public class TemplateArchiveCommand extends Command {
+
+    public static final String COMMAND_WORD = "archive";
+
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Archive a template by index."
+            + "Parameters: INDEX (must be a positive integer) "
+            + "Example: " + COMMAND_WORD + " 1 ";
+
+    public static final String MESSAGE_ARCHIVE_TEMPLATE_SUCCESS = "Archived Template: %1$s";
+    public static final String MESSAGE_NOT_ARCHIVED = "Please specify the index of the template that you want to archive.";
+    public static final String MESSAGE_ALREADY_ARCHIVED = "This template is already archived!";
+
+    private final Index index;
+
+    /**
+     * @param index of the template in the filtered template list to archive
+     */
+    public TemplateArchiveCommand(Index index) {
+        requireNonNull(index);
+
+        this.index = index;
+    }
+
+    @Override
+    public CommandResult execute(Model model) throws CommandException {
+        requireNonNull(model);
+        List<Template> lastShownList = model.getFilteredTemplateList();
+
+        if (index.getZeroBased() >= lastShownList.size()) {
+            throw new CommandException(Messages.MESSAGE_INVALID_TEMPLATE_DISPLAYED_INDEX);
+        }
+
+        Template templateToArchive = lastShownList.get(index.getZeroBased());
+
+        if (templateToArchive.isArchived()) {
+            throw new CommandException(MESSAGE_ALREADY_ARCHIVED);
+        }
+
+        Template archivedTemplate = createArchivedTemplate(templateToArchive);
+
+        model.setTemplate(templateToArchive, archivedTemplate);
+        CommandResult result = new CommandResult(String.format(MESSAGE_ARCHIVE_TEMPLATE_SUCCESS, templateToArchive));
+        model.commitWeme(result.getFeedbackToUser());
+        model.updateFilteredTemplateList(PREDICATE_SHOW_ALL_UNARCHIVED_TEMPLATES);
+
+        return result;
+    }
+
+    private Template createArchivedTemplate(Template template) {
+        assert template != null;
+
+        Name name = template.getName();
+        ImagePath imagePath = template.getImagePath();
+        return new Template(name, imagePath, true);
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        // short circuit if same object
+        if (other == this) {
+            return true;
+        }
+
+        // instanceof handles nulls
+        if (!(other instanceof TemplateArchiveCommand)) {
+            return false;
+        }
+
+        // state check
+        TemplateArchiveCommand e = (TemplateArchiveCommand) other;
+        return index.equals(e.index);
+    }
+
+}

--- a/src/main/java/seedu/weme/logic/commands/templatecommand/TemplateArchivesCommand.java
+++ b/src/main/java/seedu/weme/logic/commands/templatecommand/TemplateArchivesCommand.java
@@ -1,0 +1,25 @@
+package seedu.weme.logic.commands.templatecommand;
+
+import static java.util.Objects.requireNonNull;
+
+import seedu.weme.logic.commands.Command;
+import seedu.weme.logic.commands.CommandResult;
+import seedu.weme.model.Model;
+
+/**
+ * Lists all archived memes in Weme to the user.
+ */
+public class TemplateArchivesCommand extends Command {
+
+    public static final String COMMAND_WORD = "archives";
+
+    public static final String MESSAGE_SUCCESS = "Listed all archived templates";
+
+
+    @Override
+    public CommandResult execute(Model model) {
+        requireNonNull(model);
+        model.updateFilteredMemeList(template -> template.isArchived());
+        return new CommandResult(MESSAGE_SUCCESS);
+    }
+}

--- a/src/main/java/seedu/weme/logic/commands/templatecommand/TemplateArchivesCommand.java
+++ b/src/main/java/seedu/weme/logic/commands/templatecommand/TemplateArchivesCommand.java
@@ -1,6 +1,7 @@
 package seedu.weme.logic.commands.templatecommand;
 
 import static java.util.Objects.requireNonNull;
+import static seedu.weme.model.Model.PREDICATE_SHOW_ALL_ARCHIVED_TEMPLATES;
 
 import seedu.weme.logic.commands.Command;
 import seedu.weme.logic.commands.CommandResult;
@@ -19,7 +20,7 @@ public class TemplateArchivesCommand extends Command {
     @Override
     public CommandResult execute(Model model) {
         requireNonNull(model);
-        model.updateFilteredMemeList(template -> template.isArchived());
+        model.updateFilteredTemplateList(PREDICATE_SHOW_ALL_ARCHIVED_TEMPLATES);
         return new CommandResult(MESSAGE_SUCCESS);
     }
 }

--- a/src/main/java/seedu/weme/logic/commands/templatecommand/TemplateEditCommand.java
+++ b/src/main/java/seedu/weme/logic/commands/templatecommand/TemplateEditCommand.java
@@ -3,7 +3,6 @@ package seedu.weme.logic.commands.templatecommand;
 import static java.util.Objects.requireNonNull;
 import static seedu.weme.commons.util.CollectionUtil.requireAllNonNull;
 import static seedu.weme.logic.parser.util.CliSyntax.PREFIX_NAME;
-import static seedu.weme.model.Model.PREDICATE_SHOW_ALL_UNARCHIVED_TEMPLATES;
 
 import java.util.List;
 
@@ -57,7 +56,7 @@ public class TemplateEditCommand extends Command {
         }
 
         Template templateToEdit = lastShownList.get(index.getZeroBased());
-        Template editedTemplate = new Template(name, templateToEdit.getImagePath());
+        Template editedTemplate = new Template(name, templateToEdit.getImagePath(), templateToEdit.isArchived());
 
         if (!templateToEdit.isSameTemplate(editedTemplate) && model.hasTemplate(editedTemplate)) {
             throw new CommandException(MESSAGE_DUPLICATE_TEMPLATE);
@@ -66,7 +65,6 @@ public class TemplateEditCommand extends Command {
         model.setTemplate(templateToEdit, editedTemplate);
         CommandResult result = new CommandResult(String.format(MESSAGE_EDIT_TEMPLATE_SUCCESS, editedTemplate));
         model.commitWeme(result.getFeedbackToUser());
-        model.updateFilteredTemplateList(PREDICATE_SHOW_ALL_UNARCHIVED_TEMPLATES);
 
         return result;
     }

--- a/src/main/java/seedu/weme/logic/commands/templatecommand/TemplateEditCommand.java
+++ b/src/main/java/seedu/weme/logic/commands/templatecommand/TemplateEditCommand.java
@@ -3,7 +3,7 @@ package seedu.weme.logic.commands.templatecommand;
 import static java.util.Objects.requireNonNull;
 import static seedu.weme.commons.util.CollectionUtil.requireAllNonNull;
 import static seedu.weme.logic.parser.util.CliSyntax.PREFIX_NAME;
-import static seedu.weme.model.Model.PREDICATE_SHOW_ALL_TEMPLATES;
+import static seedu.weme.model.Model.PREDICATE_SHOW_ALL_UNARCHIVED_TEMPLATES;
 
 import java.util.List;
 
@@ -66,7 +66,7 @@ public class TemplateEditCommand extends Command {
         model.setTemplate(templateToEdit, editedTemplate);
         CommandResult result = new CommandResult(String.format(MESSAGE_EDIT_TEMPLATE_SUCCESS, editedTemplate));
         model.commitWeme(result.getFeedbackToUser());
-        model.updateFilteredTemplateList(PREDICATE_SHOW_ALL_TEMPLATES);
+        model.updateFilteredTemplateList(PREDICATE_SHOW_ALL_UNARCHIVED_TEMPLATES);
 
         return result;
     }

--- a/src/main/java/seedu/weme/logic/commands/templatecommand/TemplateUnarchiveCommand.java
+++ b/src/main/java/seedu/weme/logic/commands/templatecommand/TemplateUnarchiveCommand.java
@@ -27,7 +27,6 @@ public class TemplateUnarchiveCommand extends Command {
             + "Example: " + COMMAND_WORD + " 1 ";
 
     public static final String MESSAGE_UNARCHIVE_TEMPLATE_SUCCESS = "Unarchived Template: %1$s";
-    public static final String MESSAGE_NOT_UNARCHIVED = "Please specify the index of the template that you want to unarchive.";
     public static final String MESSAGE_ALREADY_UNARCHIVED = "This template is already unarchived!";
 
     private final Index index;
@@ -59,13 +58,17 @@ public class TemplateUnarchiveCommand extends Command {
         Template unarchivedTemplate = createUnarchivedTemplate(templateToUnarchive);
 
         model.setTemplate(templateToUnarchive, unarchivedTemplate);
-        CommandResult result = new CommandResult(String.format(MESSAGE_UNARCHIVE_TEMPLATE_SUCCESS, templateToUnarchive));
+        CommandResult result = new CommandResult(String.format(MESSAGE_UNARCHIVE_TEMPLATE_SUCCESS,
+                templateToUnarchive));
         model.commitWeme(result.getFeedbackToUser());
         model.updateFilteredTemplateList(PREDICATE_SHOW_ALL_ARCHIVED_TEMPLATES);
 
         return result;
     }
 
+    /**
+     * Creates an unarchived Template using the input archived Template.
+     */
     private Template createUnarchivedTemplate(Template template) {
         assert template != null;
 

--- a/src/main/java/seedu/weme/logic/commands/templatecommand/TemplateUnarchiveCommand.java
+++ b/src/main/java/seedu/weme/logic/commands/templatecommand/TemplateUnarchiveCommand.java
@@ -1,0 +1,94 @@
+package seedu.weme.logic.commands.templatecommand;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.weme.model.Model.PREDICATE_SHOW_ALL_ARCHIVED_TEMPLATES;
+
+import java.util.List;
+
+import seedu.weme.commons.core.Messages;
+import seedu.weme.commons.core.index.Index;
+import seedu.weme.logic.commands.Command;
+import seedu.weme.logic.commands.CommandResult;
+import seedu.weme.logic.commands.exceptions.CommandException;
+import seedu.weme.model.Model;
+import seedu.weme.model.imagePath.ImagePath;
+import seedu.weme.model.template.Name;
+import seedu.weme.model.template.Template;
+
+/**
+ * Likes a template in the display window.
+ */
+public class TemplateUnarchiveCommand extends Command {
+
+    public static final String COMMAND_WORD = "unarchive";
+
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Unarchive a template by index."
+            + "Parameters: INDEX (must be a positive integer) "
+            + "Example: " + COMMAND_WORD + " 1 ";
+
+    public static final String MESSAGE_UNARCHIVE_TEMPLATE_SUCCESS = "Unarchived Template: %1$s";
+    public static final String MESSAGE_NOT_UNARCHIVED = "Please specify the index of the template that you want to unarchive.";
+    public static final String MESSAGE_ALREADY_UNARCHIVED = "This template is already unarchived!";
+
+    private final Index index;
+
+    /**
+     * @param index of the template in the filtered template list to unarchive
+     */
+    public TemplateUnarchiveCommand(Index index) {
+        requireNonNull(index);
+
+        this.index = index;
+    }
+
+    @Override
+    public CommandResult execute(Model model) throws CommandException {
+        requireNonNull(model);
+        List<Template> lastShownList = model.getFilteredTemplateList();
+
+        if (index.getZeroBased() >= lastShownList.size()) {
+            throw new CommandException(Messages.MESSAGE_INVALID_TEMPLATE_DISPLAYED_INDEX);
+        }
+
+        Template templateToUnarchive = lastShownList.get(index.getZeroBased());
+
+        if (!templateToUnarchive.isArchived()) {
+            throw new CommandException(MESSAGE_ALREADY_UNARCHIVED);
+        }
+
+        Template unarchivedTemplate = createUnarchivedTemplate(templateToUnarchive);
+
+        model.setTemplate(templateToUnarchive, unarchivedTemplate);
+        CommandResult result = new CommandResult(String.format(MESSAGE_UNARCHIVE_TEMPLATE_SUCCESS, templateToUnarchive));
+        model.commitWeme(result.getFeedbackToUser());
+        model.updateFilteredTemplateList(PREDICATE_SHOW_ALL_ARCHIVED_TEMPLATES);
+
+        return result;
+    }
+
+    private Template createUnarchivedTemplate(Template template) {
+        assert template != null;
+
+        Name name = template.getName();
+        ImagePath imagePath = template.getImagePath();
+        return new Template(name, imagePath, false);
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        // short circuit if same object
+        if (other == this) {
+            return true;
+        }
+
+        // instanceof handles nulls
+        if (!(other instanceof TemplateUnarchiveCommand)) {
+            return false;
+        }
+
+        // state check
+        TemplateUnarchiveCommand e = (TemplateUnarchiveCommand) other;
+        return index.equals(e.index);
+    }
+
+}

--- a/src/main/java/seedu/weme/logic/parser/commandparser/memecommandparser/MemeArchiveCommandParser.java
+++ b/src/main/java/seedu/weme/logic/parser/commandparser/memecommandparser/MemeArchiveCommandParser.java
@@ -1,0 +1,31 @@
+package seedu.weme.logic.parser.commandparser.memecommandparser;
+
+import static seedu.weme.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+
+import seedu.weme.commons.core.index.Index;
+import seedu.weme.logic.commands.memecommand.MemeDeleteCommand;
+import seedu.weme.logic.parser.Parser;
+import seedu.weme.logic.parser.exceptions.ParseException;
+import seedu.weme.logic.parser.util.ParserUtil;
+
+/**
+ * Parses input arguments and creates a new MemeDeleteCommand object
+ */
+public class MemeDeleteCommandParser implements Parser<MemeDeleteCommand> {
+
+    /**
+     * Parses the given {@code String} of arguments in the context of the MemeDeleteCommand
+     * and returns a MemeDeleteCommand object for execution.
+     * @throws ParseException if the user input does not conform the expected format
+     */
+    public MemeDeleteCommand parse(String args) throws ParseException {
+        try {
+            Index index = ParserUtil.parseIndex(args);
+            return new MemeDeleteCommand(index);
+        } catch (ParseException pe) {
+            throw new ParseException(
+                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, MemeDeleteCommand.MESSAGE_USAGE), pe);
+        }
+    }
+
+}

--- a/src/main/java/seedu/weme/logic/parser/commandparser/memecommandparser/MemeArchiveCommandParser.java
+++ b/src/main/java/seedu/weme/logic/parser/commandparser/memecommandparser/MemeArchiveCommandParser.java
@@ -3,28 +3,28 @@ package seedu.weme.logic.parser.commandparser.memecommandparser;
 import static seedu.weme.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 
 import seedu.weme.commons.core.index.Index;
-import seedu.weme.logic.commands.memecommand.MemeDeleteCommand;
+import seedu.weme.logic.commands.memecommand.MemeArchiveCommand;
 import seedu.weme.logic.parser.Parser;
 import seedu.weme.logic.parser.exceptions.ParseException;
 import seedu.weme.logic.parser.util.ParserUtil;
 
 /**
- * Parses input arguments and creates a new MemeDeleteCommand object
+ * Parses input arguments and creates a new MemeArchiveCommand object
  */
-public class MemeDeleteCommandParser implements Parser<MemeDeleteCommand> {
+public class MemeArchiveCommandParser implements Parser<MemeArchiveCommand> {
 
     /**
-     * Parses the given {@code String} of arguments in the context of the MemeDeleteCommand
-     * and returns a MemeDeleteCommand object for execution.
+     * Parses the given {@code String} of arguments in the context of the MemeArchiveCommand
+     * and returns a MemeArchiveCommand object for execution.
      * @throws ParseException if the user input does not conform the expected format
      */
-    public MemeDeleteCommand parse(String args) throws ParseException {
+    public MemeArchiveCommand parse(String args) throws ParseException {
         try {
             Index index = ParserUtil.parseIndex(args);
-            return new MemeDeleteCommand(index);
+            return new MemeArchiveCommand(index);
         } catch (ParseException pe) {
             throw new ParseException(
-                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, MemeDeleteCommand.MESSAGE_USAGE), pe);
+                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, MemeArchiveCommand.MESSAGE_USAGE), pe);
         }
     }
 

--- a/src/main/java/seedu/weme/logic/parser/commandparser/memecommandparser/MemeUnarchiveCommandParser.java
+++ b/src/main/java/seedu/weme/logic/parser/commandparser/memecommandparser/MemeUnarchiveCommandParser.java
@@ -1,0 +1,31 @@
+package seedu.weme.logic.parser.commandparser.memecommandparser;
+
+import static seedu.weme.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+
+import seedu.weme.commons.core.index.Index;
+import seedu.weme.logic.commands.memecommand.MemeUnarchiveCommand;
+import seedu.weme.logic.parser.Parser;
+import seedu.weme.logic.parser.exceptions.ParseException;
+import seedu.weme.logic.parser.util.ParserUtil;
+
+/**
+ * Parses input arguments and creates a new MemeUnarchiveCommand object
+ */
+public class MemeUnarchiveCommandParser implements Parser<MemeUnarchiveCommand> {
+
+    /**
+     * Parses the given {@code String} of arguments in the context of the MemeUnarchiveCommand
+     * and returns a MemeUnarchiveCommand object for execution.
+     * @throws ParseException if the user input does not conform the expected format
+     */
+    public MemeUnarchiveCommand parse(String args) throws ParseException {
+        try {
+            Index index = ParserUtil.parseIndex(args);
+            return new MemeUnarchiveCommand(index);
+        } catch (ParseException pe) {
+            throw new ParseException(
+                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, MemeUnarchiveCommand.MESSAGE_USAGE), pe);
+        }
+    }
+
+}

--- a/src/main/java/seedu/weme/logic/parser/commandparser/templatecommandparser/TemplateArchiveCommandParser.java
+++ b/src/main/java/seedu/weme/logic/parser/commandparser/templatecommandparser/TemplateArchiveCommandParser.java
@@ -1,0 +1,31 @@
+package seedu.weme.logic.parser.commandparser.templatecommandparser;
+
+import static seedu.weme.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+
+import seedu.weme.commons.core.index.Index;
+import seedu.weme.logic.commands.templatecommand.TemplateArchiveCommand;
+import seedu.weme.logic.parser.Parser;
+import seedu.weme.logic.parser.exceptions.ParseException;
+import seedu.weme.logic.parser.util.ParserUtil;
+
+/**
+ * Parses input arguments and creates a new TemplateArchiveCommand object
+ */
+public class TemplateArchiveCommandParser implements Parser<TemplateArchiveCommand> {
+
+    /**
+     * Parses the given {@code String} of arguments in the context of the TemplateArchiveCommand
+     * and returns a TemplateArchiveCommand object for execution.
+     * @throws ParseException if the user input does not conform the expected format
+     */
+    public TemplateArchiveCommand parse(String args) throws ParseException {
+        try {
+            Index index = ParserUtil.parseIndex(args);
+            return new TemplateArchiveCommand(index);
+        } catch (ParseException pe) {
+            throw new ParseException(
+                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, TemplateArchiveCommand.MESSAGE_USAGE), pe);
+        }
+    }
+
+}

--- a/src/main/java/seedu/weme/logic/parser/commandparser/templatecommandparser/TemplateUnarchiveCommandParser.java
+++ b/src/main/java/seedu/weme/logic/parser/commandparser/templatecommandparser/TemplateUnarchiveCommandParser.java
@@ -1,0 +1,31 @@
+package seedu.weme.logic.parser.commandparser.templatecommandparser;
+
+import static seedu.weme.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+
+import seedu.weme.commons.core.index.Index;
+import seedu.weme.logic.commands.templatecommand.TemplateUnarchiveCommand;
+import seedu.weme.logic.parser.Parser;
+import seedu.weme.logic.parser.exceptions.ParseException;
+import seedu.weme.logic.parser.util.ParserUtil;
+
+/**
+ * Parses input arguments and creates a new TemplateUnarchiveCommand object
+ */
+public class TemplateUnarchiveCommandParser implements Parser<TemplateUnarchiveCommand> {
+
+    /**
+     * Parses the given {@code String} of arguments in the context of the TemplateUnarchiveCommand
+     * and returns a TemplateUnarchiveCommand object for execution.
+     * @throws ParseException if the user input does not conform the expected format
+     */
+    public TemplateUnarchiveCommand parse(String args) throws ParseException {
+        try {
+            Index index = ParserUtil.parseIndex(args);
+            return new TemplateUnarchiveCommand(index);
+        } catch (ParseException pe) {
+            throw new ParseException(
+                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, TemplateUnarchiveCommand.MESSAGE_USAGE), pe);
+        }
+    }
+
+}

--- a/src/main/java/seedu/weme/logic/parser/contextparser/MemeParser.java
+++ b/src/main/java/seedu/weme/logic/parser/contextparser/MemeParser.java
@@ -7,13 +7,13 @@ import java.util.regex.Matcher;
 import seedu.weme.logic.commands.Command;
 import seedu.weme.logic.commands.generalcommand.HelpCommand;
 import seedu.weme.logic.commands.memecommand.MemeAddCommand;
+import seedu.weme.logic.commands.memecommand.MemeArchivesCommand;
 import seedu.weme.logic.commands.memecommand.MemeClearCommand;
 import seedu.weme.logic.commands.memecommand.MemeDeleteCommand;
 import seedu.weme.logic.commands.memecommand.MemeEditCommand;
 import seedu.weme.logic.commands.memecommand.MemeFindCommand;
 import seedu.weme.logic.commands.memecommand.MemeLikeCommand;
 import seedu.weme.logic.commands.memecommand.MemeListCommand;
-
 import seedu.weme.logic.commands.memecommand.MemeStageCommand;
 import seedu.weme.logic.parser.commandparser.memecommandparser.MemeAddCommandParser;
 import seedu.weme.logic.parser.commandparser.memecommandparser.MemeDeleteCommandParser;
@@ -69,6 +69,9 @@ public class MemeParser extends WemeParser {
 
         case MemeStageCommand.COMMAND_WORD:
             return new MemeStageCommandParser().parse(arguments);
+
+        case MemeArchivesCommand.COMMAND_WORD:
+            return new MemeArchivesCommand();
 
 
         default:

--- a/src/main/java/seedu/weme/logic/parser/contextparser/MemeParser.java
+++ b/src/main/java/seedu/weme/logic/parser/contextparser/MemeParser.java
@@ -7,6 +7,7 @@ import java.util.regex.Matcher;
 import seedu.weme.logic.commands.Command;
 import seedu.weme.logic.commands.generalcommand.HelpCommand;
 import seedu.weme.logic.commands.memecommand.MemeAddCommand;
+import seedu.weme.logic.commands.memecommand.MemeArchiveCommand;
 import seedu.weme.logic.commands.memecommand.MemeArchivesCommand;
 import seedu.weme.logic.commands.memecommand.MemeClearCommand;
 import seedu.weme.logic.commands.memecommand.MemeDeleteCommand;
@@ -15,12 +16,15 @@ import seedu.weme.logic.commands.memecommand.MemeFindCommand;
 import seedu.weme.logic.commands.memecommand.MemeLikeCommand;
 import seedu.weme.logic.commands.memecommand.MemeListCommand;
 import seedu.weme.logic.commands.memecommand.MemeStageCommand;
+import seedu.weme.logic.commands.memecommand.MemeUnarchiveCommand;
 import seedu.weme.logic.parser.commandparser.memecommandparser.MemeAddCommandParser;
+import seedu.weme.logic.parser.commandparser.memecommandparser.MemeArchiveCommandParser;
 import seedu.weme.logic.parser.commandparser.memecommandparser.MemeDeleteCommandParser;
 import seedu.weme.logic.parser.commandparser.memecommandparser.MemeEditCommandParser;
 import seedu.weme.logic.parser.commandparser.memecommandparser.MemeFindCommandParser;
 import seedu.weme.logic.parser.commandparser.memecommandparser.MemeLikeCommandParser;
 import seedu.weme.logic.parser.commandparser.memecommandparser.MemeStageCommandParser;
+import seedu.weme.logic.parser.commandparser.memecommandparser.MemeUnarchiveCommandParser;
 import seedu.weme.logic.parser.exceptions.ParseException;
 
 /**
@@ -73,6 +77,11 @@ public class MemeParser extends WemeParser {
         case MemeArchivesCommand.COMMAND_WORD:
             return new MemeArchivesCommand();
 
+        case MemeArchiveCommand.COMMAND_WORD:
+            return new MemeArchiveCommandParser().parse(arguments);
+
+        case MemeUnarchiveCommand.COMMAND_WORD:
+            return new MemeUnarchiveCommandParser().parse(arguments);
 
         default:
             return super.parseCommand(userInput);

--- a/src/main/java/seedu/weme/logic/parser/contextparser/TemplateParser.java
+++ b/src/main/java/seedu/weme/logic/parser/contextparser/TemplateParser.java
@@ -7,6 +7,7 @@ import java.util.regex.Matcher;
 import seedu.weme.logic.commands.Command;
 import seedu.weme.logic.commands.generalcommand.HelpCommand;
 import seedu.weme.logic.commands.templatecommand.TemplateAddCommand;
+import seedu.weme.logic.commands.templatecommand.TemplateArchivesCommand;
 import seedu.weme.logic.commands.templatecommand.TemplateDeleteCommand;
 import seedu.weme.logic.commands.templatecommand.TemplateEditCommand;
 import seedu.weme.logic.commands.templatecommand.TemplateUseCommand;
@@ -50,6 +51,9 @@ public class TemplateParser extends WemeParser {
 
         case TemplateUseCommand.COMMAND_WORD:
             return new TemplateUseCommandParser().parse(arguments);
+
+        case TemplateArchivesCommand.COMMAND_WORD:
+            return new TemplateArchivesCommand();
 
         default:
             return super.parseCommand(userInput);

--- a/src/main/java/seedu/weme/logic/parser/contextparser/TemplateParser.java
+++ b/src/main/java/seedu/weme/logic/parser/contextparser/TemplateParser.java
@@ -7,13 +7,17 @@ import java.util.regex.Matcher;
 import seedu.weme.logic.commands.Command;
 import seedu.weme.logic.commands.generalcommand.HelpCommand;
 import seedu.weme.logic.commands.templatecommand.TemplateAddCommand;
+import seedu.weme.logic.commands.templatecommand.TemplateArchiveCommand;
 import seedu.weme.logic.commands.templatecommand.TemplateArchivesCommand;
 import seedu.weme.logic.commands.templatecommand.TemplateDeleteCommand;
 import seedu.weme.logic.commands.templatecommand.TemplateEditCommand;
+import seedu.weme.logic.commands.templatecommand.TemplateUnarchiveCommand;
 import seedu.weme.logic.commands.templatecommand.TemplateUseCommand;
 import seedu.weme.logic.parser.commandparser.templatecommandparser.TemplateAddCommandParser;
+import seedu.weme.logic.parser.commandparser.templatecommandparser.TemplateArchiveCommandParser;
 import seedu.weme.logic.parser.commandparser.templatecommandparser.TemplateDeleteCommandParser;
 import seedu.weme.logic.parser.commandparser.templatecommandparser.TemplateEditCommandParser;
+import seedu.weme.logic.parser.commandparser.templatecommandparser.TemplateUnarchiveCommandParser;
 import seedu.weme.logic.parser.commandparser.templatecommandparser.TemplateUseCommandParser;
 import seedu.weme.logic.parser.exceptions.ParseException;
 
@@ -54,6 +58,12 @@ public class TemplateParser extends WemeParser {
 
         case TemplateArchivesCommand.COMMAND_WORD:
             return new TemplateArchivesCommand();
+
+        case TemplateArchiveCommand.COMMAND_WORD:
+            return new TemplateArchiveCommandParser().parse(arguments);
+
+        case TemplateUnarchiveCommand.COMMAND_WORD:
+            return new TemplateUnarchiveCommandParser().parse(arguments);
 
         default:
             return super.parseCommand(userInput);

--- a/src/main/java/seedu/weme/model/Archivable.java
+++ b/src/main/java/seedu/weme/model/Archivable.java
@@ -1,0 +1,13 @@
+package seedu.weme.model;
+
+/**
+ * Makes a resource archivable, requires an instance field {@code isArchived} as well.
+ */
+public interface Archivable {
+
+    /**
+     * Returns whether the implementing resource is archived.
+     */
+    boolean isArchived();
+
+}

--- a/src/main/java/seedu/weme/model/Model.java
+++ b/src/main/java/seedu/weme/model/Model.java
@@ -21,10 +21,14 @@ import seedu.weme.model.template.Template;
  * The API of the Model component.
  */
 public interface Model {
-    /** {@code Predicate} that always evaluate to true */
-    Predicate<Meme> PREDICATE_SHOW_ALL_MEMES = meme -> !meme.isArchived();
-    /** {@code Predicate} that always evaluate to true */
-    Predicate<Template> PREDICATE_SHOW_ALL_TEMPLATES = template -> !template.isArchived();
+    /** {@code Predicate} that evaluates to true if unarchived */
+    Predicate<Meme> PREDICATE_SHOW_ALL_UNARCHIVED_MEMES = meme -> !meme.isArchived();
+    /** {@code Predicate} that evaluate to true if unarchived */
+    Predicate<Template> PREDICATE_SHOW_ALL_UNARCHIVED_TEMPLATES = template -> !template.isArchived();
+    /** {@code Predicate} that evaluate to true if archived */
+    Predicate<Meme> PREDICATE_SHOW_ALL_ARCHIVED_MEMES = meme -> meme.isArchived();
+    /** {@code Predicate} that evaluate to true if archived */
+    Predicate<Template> PREDICATE_SHOW_ALL_ARCHIVED_TEMPLATES = template -> template.isArchived();
 
     /**
      * Replaces user prefs data with the data in {@code userPrefs}.

--- a/src/main/java/seedu/weme/model/Model.java
+++ b/src/main/java/seedu/weme/model/Model.java
@@ -22,9 +22,9 @@ import seedu.weme.model.template.Template;
  */
 public interface Model {
     /** {@code Predicate} that always evaluate to true */
-    Predicate<Meme> PREDICATE_SHOW_ALL_MEMES = unused -> true;
+    Predicate<Meme> PREDICATE_SHOW_ALL_MEMES = meme -> !meme.isArchived();
     /** {@code Predicate} that always evaluate to true */
-    Predicate<Template> PREDICATE_SHOW_ALL_TEMPLATES = unused -> true;
+    Predicate<Template> PREDICATE_SHOW_ALL_TEMPLATES = template -> !template.isArchived();
 
     /**
      * Replaces user prefs data with the data in {@code userPrefs}.

--- a/src/main/java/seedu/weme/model/ModelManager.java
+++ b/src/main/java/seedu/weme/model/ModelManager.java
@@ -183,7 +183,7 @@ public class ModelManager implements Model {
     @Override
     public void addMeme(Meme meme) {
         versionedWeme.addMeme(meme);
-        updateFilteredMemeList(PREDICATE_SHOW_ALL_MEMES);
+        updateFilteredMemeList(PREDICATE_SHOW_ALL_UNARCHIVED_MEMES);
     }
 
     @Override
@@ -217,7 +217,7 @@ public class ModelManager implements Model {
     @Override
     public void addTemplate(Template template) {
         versionedWeme.addTemplate(template);
-        updateFilteredTemplateList(PREDICATE_SHOW_ALL_TEMPLATES);
+        updateFilteredTemplateList(PREDICATE_SHOW_ALL_UNARCHIVED_TEMPLATES);
     }
 
     @Override

--- a/src/main/java/seedu/weme/model/ModelManager.java
+++ b/src/main/java/seedu/weme/model/ModelManager.java
@@ -56,10 +56,11 @@ public class ModelManager implements Model {
 
         versionedWeme = new VersionedWeme(weme);
         this.userPrefs = new UserPrefs(userPrefs);
-        filteredMemes = new FilteredList<>(versionedWeme.getMemeList());
+        filteredMemes = new FilteredList<>(versionedWeme.getMemeList(), PREDICATE_SHOW_ALL_UNARCHIVED_MEMES);
         filteredStagedMemeList = new FilteredList<>(versionedWeme.getStagedMemeList());
         filteredImportMemeList = new FilteredList<>(versionedWeme.getImportList());
-        filteredTemplates = new FilteredList<>(versionedWeme.getTemplateList());
+        filteredTemplates = new FilteredList<>(versionedWeme.getTemplateList(),
+                PREDICATE_SHOW_ALL_UNARCHIVED_TEMPLATES);
     }
 
     public ModelManager() {

--- a/src/main/java/seedu/weme/model/meme/Meme.java
+++ b/src/main/java/seedu/weme/model/meme/Meme.java
@@ -7,6 +7,7 @@ import java.util.HashSet;
 import java.util.Objects;
 import java.util.Set;
 
+import seedu.weme.model.Archivable;
 import seedu.weme.model.imagePath.ImagePath;
 import seedu.weme.model.tag.Tag;
 
@@ -14,7 +15,7 @@ import seedu.weme.model.tag.Tag;
  * Represents a Meme in Weme.
  * Guarantees: details are present and not null, field values are validated, immutable.
  */
-public class Meme {
+public class Meme implements Archivable {
 
     // Identity fields
     private final ImagePath imagePath;
@@ -22,23 +23,31 @@ public class Meme {
     // Data fields
     private final Description description;
     private final Set<Tag> tags = new HashSet<>();
+    private final boolean isArchived;
 
     /**
      * Every field must be present and not null.
      */
-    public Meme(ImagePath imagePath, Description description, Set<Tag> tags) {
+    public Meme(ImagePath imagePath, Description description, Set<Tag> tags, boolean isArchived) {
         requireAllNonNull(imagePath, description, tags);
         this.imagePath = imagePath;
         this.description = description;
         this.tags.addAll(tags);
+        this.isArchived = isArchived;
+    }
+
+    /**
+     * Overloaded Constructor for unarchived memes.
+     */
+    public Meme(ImagePath imagePath, Description description, Set<Tag> tags) {
+        this(imagePath, description, tags, false);
     }
 
     /**
      * Overloaded Constructor used to generate imported memes.
      */
-    public Meme(ImagePath path) {
-        this.imagePath = path;
-        this.description = new Description("");
+    public Meme(ImagePath imagePath) {
+        this(imagePath, new Description(""), new HashSet<>(), false);
     }
 
     public Description getDescription() {
@@ -55,6 +64,10 @@ public class Meme {
      */
     public Set<Tag> getTags() {
         return Collections.unmodifiableSet(tags);
+    }
+
+    public boolean isArchived() {
+        return isArchived;
     }
 
     /**
@@ -87,13 +100,14 @@ public class Meme {
         Meme otherMeme = (Meme) other;
         return otherMeme.getImagePath().equals(getImagePath())
                 && otherMeme.getDescription().equals(getDescription())
-                && otherMeme.getTags().equals(getTags());
+                && otherMeme.getTags().equals(getTags())
+                && otherMeme.isArchived() == isArchived();
     }
 
     @Override
     public int hashCode() {
         // use this method for custom fields hashing instead of implementing your own
-        return Objects.hash(imagePath, description, tags);
+        return Objects.hash(imagePath, description, tags, isArchived);
     }
 
     @Override

--- a/src/main/java/seedu/weme/model/template/Template.java
+++ b/src/main/java/seedu/weme/model/template/Template.java
@@ -4,27 +4,34 @@ import static seedu.weme.commons.util.CollectionUtil.requireAllNonNull;
 
 import java.util.Objects;
 
+import seedu.weme.model.Archivable;
 import seedu.weme.model.imagePath.ImagePath;
 
 /**
  * Represents a meme template in Weme.
  * Guarantees: details are present and not null, field values are validated, immutable.
  */
-public class Template {
+public class Template implements Archivable {
 
     // Identity fields
     private final Name name;
 
     // Data fields
     private final ImagePath imagePath;
+    private final boolean isArchived;
 
     /**
      * Every field must be present and not null.
      */
-    public Template(Name name, ImagePath imagePath) {
+    public Template(Name name, ImagePath imagePath, boolean isArchived) {
         requireAllNonNull(imagePath, name);
         this.name = name;
         this.imagePath = imagePath;
+        this.isArchived = isArchived;
+    }
+
+    public Template(Name name, ImagePath imagePath) {
+        this(name, imagePath, false);
     }
 
     public Name getName() {
@@ -33,6 +40,10 @@ public class Template {
 
     public ImagePath getImagePath() {
         return imagePath;
+    }
+
+    public boolean isArchived() {
+        return isArchived;
     }
 
     /**

--- a/src/main/java/seedu/weme/storage/JsonAdaptedMeme.java
+++ b/src/main/java/seedu/weme/storage/JsonAdaptedMeme.java
@@ -25,19 +25,22 @@ class JsonAdaptedMeme {
     private final String description;
     private final String filePath;
     private final List<JsonAdaptedTag> tagged = new ArrayList<>();
+    private final boolean isArchived;
 
     /**
      * Constructs a {@code JsonAdaptedMeme} with the given meme details.
      */
     @JsonCreator
     public JsonAdaptedMeme(@JsonProperty("filePath") String filePath, @JsonProperty("description") String description,
-                           @JsonProperty("tagged") List<JsonAdaptedTag> tagged) {
+                           @JsonProperty("tagged") List<JsonAdaptedTag> tagged,
+                           @JsonProperty("isArchived") boolean isArchived) {
 
         this.filePath = filePath;
         this.description = description;
         if (tagged != null) {
             this.tagged.addAll(tagged);
         }
+        this.isArchived = isArchived;
     }
 
     /**
@@ -49,6 +52,7 @@ class JsonAdaptedMeme {
         tagged.addAll(source.getTags().stream()
                 .map(JsonAdaptedTag::new)
                 .collect(Collectors.toList()));
+        isArchived = source.isArchived();
     }
 
     /**
@@ -81,7 +85,7 @@ class JsonAdaptedMeme {
         final Description modelDescription = new Description(description);
 
         final Set<Tag> modelTags = new HashSet<>(memeTags);
-        return new Meme(modelUrl, modelDescription, modelTags);
+        return new Meme(modelUrl, modelDescription, modelTags, isArchived);
     }
 
 }

--- a/src/main/java/seedu/weme/storage/JsonAdaptedTemplate.java
+++ b/src/main/java/seedu/weme/storage/JsonAdaptedTemplate.java
@@ -17,14 +17,17 @@ class JsonAdaptedTemplate {
 
     private final String name;
     private final String filePath;
+    private final boolean isArchived;
 
     /**
      * Constructs a {@code JsonAdaptedTemplate} with the given template details.
      */
     @JsonCreator
-    public JsonAdaptedTemplate(@JsonProperty("name") String name, @JsonProperty("filePath") String filePath) {
+    public JsonAdaptedTemplate(@JsonProperty("name") String name, @JsonProperty("filePath") String filePath,
+                               @JsonProperty("isArchived") boolean isArchived) {
         this.name = name;
         this.filePath = filePath;
+        this.isArchived = isArchived;
     }
 
     /**
@@ -33,6 +36,7 @@ class JsonAdaptedTemplate {
     public JsonAdaptedTemplate(Template source) {
         name = source.getName().toString();
         filePath = source.getImagePath().toString();
+        isArchived = source.isArchived();
     }
 
     /**
@@ -58,7 +62,7 @@ class JsonAdaptedTemplate {
         }
         final ImagePath modelFilePath = new ImagePath(filePath);
 
-        return new Template(modelName, modelFilePath);
+        return new Template(modelName, modelFilePath, isArchived);
     }
 
 }

--- a/src/test/data/JsonSerializableWemeTest/duplicateMemeWeme.json
+++ b/src/test/data/JsonSerializableWemeTest/duplicateMemeWeme.json
@@ -2,11 +2,13 @@
   "memes" : [ {
     "filePath": "src/test/data/memes/charmander_meme.jpg",
     "tagged" : [ "charmander" ],
-    "description" : "A meme about Char and charmander."
+    "description" : "A meme about Char and charmander.",
+    "isArchived": false
   }, {
     "filePath": "src/test/data/memes/charmander_meme.jpg",
     "tagged": [ "charmander" ],
-    "description": "A meme about Char and charmander."
+    "description": "A meme about Char and charmander.",
+    "isArchived": false
   } ],
   "templates": [],
   "stats" : {

--- a/src/test/data/JsonSerializableWemeTest/duplicateTemplateWeme.json
+++ b/src/test/data/JsonSerializableWemeTest/duplicateTemplateWeme.json
@@ -2,10 +2,12 @@
   "memes": [],
   "templates" : [ {
     "name" : "Drake Reaction",
-    "filePath": "src/test/data/templates/drake_template.jpg"
+    "filePath": "src/test/data/templates/drake_template.jpg",
+    "isArchived": false
   }, {
     "name" : "Drake Reaction",
-    "filePath": "src/test/data/templates/drake_template.jpg"
+    "filePath": "src/test/data/templates/drake_template.jpg",
+    "isArchived": false
   } ],
   "stats" : {
     "likeMap" : {}

--- a/src/test/data/JsonSerializableWemeTest/invalidMemeWeme.json
+++ b/src/test/data/JsonSerializableWemeTest/invalidMemeWeme.json
@@ -3,12 +3,14 @@
     {
       "description": "Popular Meme among NUS Students",
       "tagged": [ "friends" ],
-      "filePath": "Hello world"
+      "filePath": "Hello world",
+      "isArchived": false
     },
     {
     "description": "Popular Meme among NUS Students",
     "tagged": [ "friends" ],
-    "filePath": "https://tinyurl.com/testWeme"
+    "filePath": "https://tinyurl.com/testWeme",
+      "isArchived": false
   } ],
   "templates": [],
   "stats" : {

--- a/src/test/data/JsonSerializableWemeTest/invalidTemplateWeme.json
+++ b/src/test/data/JsonSerializableWemeTest/invalidTemplateWeme.json
@@ -2,10 +2,12 @@
   "memes": [],
   "templates": [{
     "name" : "Drake Reaction",
-    "filePath": "An invalid path"
+    "filePath": "An invalid path",
+    "isArchived": false
   }, {
     "name" : "",
-    "filePath": "src/test/data/templates/is_this_template.jpg"
+    "filePath": "src/test/data/templates/is_this_template.jpg",
+    "isArchived": false
   } ],
   "stats" : {
     "likeMap" : {}

--- a/src/test/data/JsonSerializableWemeTest/typicalWeme.json
+++ b/src/test/data/JsonSerializableWemeTest/typicalWeme.json
@@ -3,29 +3,36 @@
   "memes" : [ {
     "filePath": "src/test/data/memes/charmander_meme.jpg",
     "tagged" : [ "charmander" ],
-    "description" : "A meme about Char and charmander."
+    "description" : "A meme about Char and charmander.",
+    "isArchived": false
   }, {
     "filePath": "src/test/data/memes/doge_meme.jpg",
     "tagged" : ["doge"],
-    "description" : "A meme about doge."
+    "description" : "A meme about doge.",
+    "isArchived": false
   }, {
     "filePath": "src/test/data/memes/joker_meme.jpg",
     "tagged" : ["joker"],
-    "description" : "A meme about joker."
+    "description" : "A meme about joker.",
+    "isArchived": false
   }, {
     "filePath": "src/test/data/memes/toy_meme.jpg",
     "tagged" : ["toy"],
-    "description" : "A toy story meme."
+    "description" : "A toy story meme.",
+    "isArchived": false
   }],
   "templates" : [ {
     "name" : "Drake Reaction",
-    "filePath": "src/test/data/templates/drake_template.jpg"
+    "filePath": "src/test/data/templates/drake_template.jpg",
+    "isArchived": false
   }, {
     "name" : "Is This",
-    "filePath": "src/test/data/templates/is_this_template.jpg"
+    "filePath": "src/test/data/templates/is_this_template.jpg",
+    "isArchived": false
   }, {
     "name" : "Quiz Kid",
-    "filePath": "src/test/data/templates/quiz_kid_template.jpg"
+    "filePath": "src/test/data/templates/quiz_kid_template.jpg",
+    "isArchived": false
   } ],
   "stats" : {
     "likeMap" : {

--- a/src/test/data/JsonWemeStorageTest/invalidAndValidMemeWeme.json
+++ b/src/test/data/JsonWemeStorageTest/invalidAndValidMemeWeme.json
@@ -1,9 +1,11 @@
 {
   "memes": [ {
     "description": "A meme about Pikachu.",
-    "filePath": "Hello Pikachu"
+    "filePath": "Hello Pikachu",
+    "isArchived": false
   }, {
     "description": "",
-    "filePath": "test/data/memes/Pikachu.jpg"
+    "filePath": "test/data/memes/Pikachu.jpg",
+    "isArchived": false
   } ]
 }

--- a/src/test/data/JsonWemeStorageTest/invalidMemeWeme.json
+++ b/src/test/data/JsonWemeStorageTest/invalidMemeWeme.json
@@ -1,6 +1,7 @@
 {
   "memes": [ {
     "description": "4th street",
-    "filePath": "Hello world."
+    "filePath": "Hello world.",
+    "isArchived": false
   } ]
 }

--- a/src/test/java/seedu/weme/logic/commands/memecommand/MemeEditCommandTest.java
+++ b/src/test/java/seedu/weme/logic/commands/memecommand/MemeEditCommandTest.java
@@ -100,6 +100,7 @@ public class MemeEditCommandTest {
         Model expectedModel = new ModelManager(new Weme(model.getWeme()), new UserPrefs());
         expectedModel.setMeme(model.getFilteredMemeList().get(0), editedMeme);
         expectedModel.commitWeme(expectedMessage);
+        showMemeAtIndex(expectedModel, INDEX_FIRST_MEME);
 
         assertCommandSuccess(memeEditCommand, model, expectedMessage, expectedModel);
     }

--- a/src/test/java/seedu/weme/model/ModelManagerTest.java
+++ b/src/test/java/seedu/weme/model/ModelManagerTest.java
@@ -3,7 +3,7 @@ package seedu.weme.model;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static seedu.weme.model.Model.PREDICATE_SHOW_ALL_MEMES;
+import static seedu.weme.model.Model.PREDICATE_SHOW_ALL_UNARCHIVED_MEMES;
 import static seedu.weme.testutil.Assert.assertThrows;
 import static seedu.weme.testutil.TypicalMemes.DOGE;
 import static seedu.weme.testutil.TypicalMemes.JOKER;
@@ -121,7 +121,7 @@ public class ModelManagerTest {
         assertFalse(modelManager.equals(new ModelManager(differentWeme, userPrefs)));
 
         // resets modelManager to initial state for upcoming tests
-        modelManager.updateFilteredMemeList(PREDICATE_SHOW_ALL_MEMES);
+        modelManager.updateFilteredMemeList(PREDICATE_SHOW_ALL_UNARCHIVED_MEMES);
 
         // different filteredList -> returns false
         String[] keywords = JOKER.getImagePath().toString().split("\\s+");

--- a/src/test/java/seedu/weme/storage/JsonAdaptedMemeTest.java
+++ b/src/test/java/seedu/weme/storage/JsonAdaptedMemeTest.java
@@ -33,20 +33,20 @@ public class JsonAdaptedMemeTest {
 
     @Test
     public void toModelType_nullPath_throwsIllegalValueException() {
-        JsonAdaptedMeme meme = new JsonAdaptedMeme(null, VALID_DESCRIPTION, VALID_TAGS);
+        JsonAdaptedMeme meme = new JsonAdaptedMeme(null, VALID_DESCRIPTION, VALID_TAGS, false);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, ImagePath.class.getSimpleName());
         assertThrows(IllegalValueException.class, expectedMessage, meme::toModelType);
     }
 
     @Test
     public void toModelType_invalidPath_throwsIllegalValueException() {
-        JsonAdaptedMeme meme = new JsonAdaptedMeme(INVALID_URL, VALID_DESCRIPTION, VALID_TAGS);
+        JsonAdaptedMeme meme = new JsonAdaptedMeme(INVALID_URL, VALID_DESCRIPTION, VALID_TAGS, false);
         assertThrows(IllegalValueException.class, meme::toModelType);
     }
 
     @Test
     public void toModelType_nullDescription_throwsIllegalValueException() {
-        JsonAdaptedMeme meme = new JsonAdaptedMeme(VALID_URL, null, VALID_TAGS);
+        JsonAdaptedMeme meme = new JsonAdaptedMeme(VALID_URL, null, VALID_TAGS, false);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Description.class.getSimpleName());
         assertThrows(IllegalValueException.class, expectedMessage, meme::toModelType);
     }
@@ -56,7 +56,7 @@ public class JsonAdaptedMemeTest {
         List<JsonAdaptedTag> invalidTags = new ArrayList<>(VALID_TAGS);
         invalidTags.add(new JsonAdaptedTag(INVALID_TAG));
         JsonAdaptedMeme meme =
-                new JsonAdaptedMeme(VALID_URL, VALID_DESCRIPTION, invalidTags);
+                new JsonAdaptedMeme(VALID_URL, VALID_DESCRIPTION, invalidTags, false);
         assertThrows(IllegalValueException.class, meme::toModelType);
     }
 


### PR DESCRIPTION
- Added an interface Archivable to force implementing classes to have an `isArchived` method.

- Users can now use `archive INDEX` and `unarchive INDEX` to archive and unarchive a meme or template.
- Users can view archived memes / templates using `archives`. Go back to the original view using `list`