### PR TITLE
Optimize GUI performance

### DIFF
--- a/src/main/java/seedu/weme/ui/ImportGridPanel.java
+++ b/src/main/java/seedu/weme/ui/ImportGridPanel.java
@@ -1,5 +1,7 @@
 package seedu.weme.ui;
 
+import java.util.HashMap;
+import java.util.Map;
 import java.util.logging.Logger;
 
 import org.controlsfx.control.GridCell;
@@ -8,17 +10,18 @@ import org.controlsfx.control.GridView;
 import javafx.collections.ObservableList;
 import javafx.fxml.FXML;
 import javafx.scene.layout.Region;
-
 import seedu.weme.commons.core.LogsCenter;
+import seedu.weme.model.imagePath.ImagePath;
 import seedu.weme.model.meme.Meme;
 
 
 /**
- * Panel containing the list of memes.
+ * Panel containing the list of memes in the import staging area.
  */
 public class ImportGridPanel extends UiPart<Region> {
     private static final String FXML = "ImportGridPanel.fxml";
     private final Logger logger = LogsCenter.getLogger(ImportGridPanel.class);
+    private final Map<ImagePath, ImportMemeCard> importMemeCardMap = new HashMap<>();
 
     @FXML
     private GridView<Meme> importGridView;
@@ -40,8 +43,16 @@ public class ImportGridPanel extends UiPart<Region> {
                 setGraphic(null);
                 setText(null);
             } else {
-                String filePath = meme.getImagePath().toString();
-                setGraphic(new ImportMemeCard(meme, getIndex() + 1).getRoot());
+                ImagePath imagePath = meme.getImagePath();
+                ImportMemeCard card = importMemeCardMap.get(imagePath);
+                int newIndex = getIndex() + 1;
+                if (card == null) {
+                    card = new ImportMemeCard(meme, newIndex);
+                    importMemeCardMap.put(imagePath, card);
+                } else {
+                    card.update(meme, newIndex);
+                }
+                setGraphic(card.getRoot());
             }
         }
     }

--- a/src/main/java/seedu/weme/ui/ImportMemeCard.java
+++ b/src/main/java/seedu/weme/ui/ImportMemeCard.java
@@ -50,6 +50,20 @@ public class ImportMemeCard extends UiPart<Region> {
                 .forEach(tag -> tags.getChildren().add(new Label(tag.tagName)));
     }
 
+    /**
+     * Updates the card content except for the meme image.
+     * @param meme the meme this card is for
+     * @param newIndex the new index of the this card
+     */
+    public void update(Meme meme, int newIndex) {
+        id.setText(newIndex + "");
+        description.setText(meme.getDescription().value);
+        tags.getChildren().clear();
+        meme.getTags().stream()
+                .sorted(Comparator.comparing(tag -> tag.tagName))
+                .forEach(tag -> tags.getChildren().add(new Label(tag.tagName)));
+    }
+
     @Override
     public boolean equals(Object other) {
         // short circuit if same object

--- a/src/main/java/seedu/weme/ui/ImportMemeCard.java
+++ b/src/main/java/seedu/weme/ui/ImportMemeCard.java
@@ -43,7 +43,7 @@ public class ImportMemeCard extends UiPart<Region> {
         super(FXML);
         this.meme = meme;
         id.setText(displayedIndex + "");
-        display.setImage(new Image(meme.getImagePath().toUrl().toString()));
+        display.setImage(new Image(meme.getImagePath().toUrl().toString(), 200, 200, true, true));
         description.setText(meme.getDescription().value);
         meme.getTags().stream()
                 .sorted(Comparator.comparing(tag -> tag.tagName))

--- a/src/main/java/seedu/weme/ui/ImportMemeCard.java
+++ b/src/main/java/seedu/weme/ui/ImportMemeCard.java
@@ -43,7 +43,7 @@ public class ImportMemeCard extends UiPart<Region> {
         super(FXML);
         this.meme = meme;
         id.setText(displayedIndex + "");
-        display.setImage(new Image(meme.getImagePath().toUrl().toString(), 200, 200, true, true));
+        display.setImage(new Image(meme.getImagePath().toUrl().toString(), 200, 200, true, true, true));
         description.setText(meme.getDescription().value);
         meme.getTags().stream()
                 .sorted(Comparator.comparing(tag -> tag.tagName))

--- a/src/main/java/seedu/weme/ui/MemeCard.java
+++ b/src/main/java/seedu/weme/ui/MemeCard.java
@@ -64,6 +64,27 @@ public class MemeCard extends UiPart<Region> {
                 dislikes.setText(Integer.toString((int) newValue)));
     }
 
+    /**
+     * Updates the card content except for the meme image.
+     *
+     * @param meme     the meme this card is for
+     * @param newIndex the new index of the this card
+     */
+    public void update(Meme meme, int newIndex, SimpleIntegerProperty numOfLikes, SimpleIntegerProperty numOfDislikes) {
+        id.setText(newIndex + "");
+        description.setText(meme.getDescription().value);
+        tags.getChildren().clear();
+        meme.getTags().stream()
+                .sorted(Comparator.comparing(tag -> tag.tagName))
+                .forEach(tag -> tags.getChildren().add(new Label(tag.tagName)));
+        likes.setText(" " + numOfLikes.get() + " ");
+        dislikes.setText(" " + numOfDislikes.get() + " ");
+        numOfLikes.addListener((observable, oldValue, newValue) ->
+                likes.setText(Integer.toString((int) newValue)));
+        numOfDislikes.addListener((observable, oldValue, newValue) ->
+                dislikes.setText(Integer.toString((int) newValue)));
+    }
+
     @Override
     public boolean equals(Object other) {
         // short circuit if same object
@@ -79,6 +100,8 @@ public class MemeCard extends UiPart<Region> {
         // state check
         MemeCard card = (MemeCard) other;
         return id.getText().equals(card.id.getText())
-                && meme.equals(card.meme);
+                && meme.equals(card.meme)
+                && likes.equals(card.likes)
+                && dislikes.equals(card.dislikes);
     }
 }

--- a/src/main/java/seedu/weme/ui/MemeCard.java
+++ b/src/main/java/seedu/weme/ui/MemeCard.java
@@ -51,7 +51,7 @@ public class MemeCard extends UiPart<Region> {
         super(FXML);
         this.meme = meme;
         id.setText(displayedIndex + "");
-        display.setImage(new Image(meme.getImagePath().toUrl().toString(), 200, 200, true, true));
+        display.setImage(new Image(meme.getImagePath().toUrl().toString(), 200, 200, true, true, true));
         description.setText(meme.getDescription().value);
         meme.getTags().stream()
                 .sorted(Comparator.comparing(tag -> tag.tagName))

--- a/src/main/java/seedu/weme/ui/MemeCard.java
+++ b/src/main/java/seedu/weme/ui/MemeCard.java
@@ -51,7 +51,7 @@ public class MemeCard extends UiPart<Region> {
         super(FXML);
         this.meme = meme;
         id.setText(displayedIndex + "");
-        display.setImage(new Image(meme.getImagePath().toUrl().toString()));
+        display.setImage(new Image(meme.getImagePath().toUrl().toString(), 200, 200, true, true));
         description.setText(meme.getDescription().value);
         meme.getTags().stream()
                 .sorted(Comparator.comparing(tag -> tag.tagName))

--- a/src/main/java/seedu/weme/ui/MemeGridPanel.java
+++ b/src/main/java/seedu/weme/ui/MemeGridPanel.java
@@ -1,5 +1,7 @@
 package seedu.weme.ui;
 
+import java.util.HashMap;
+import java.util.Map;
 import java.util.logging.Logger;
 
 import org.controlsfx.control.GridCell;
@@ -11,6 +13,7 @@ import javafx.collections.ObservableMap;
 import javafx.fxml.FXML;
 import javafx.scene.layout.Region;
 import seedu.weme.commons.core.LogsCenter;
+import seedu.weme.model.imagePath.ImagePath;
 import seedu.weme.model.meme.Meme;
 
 
@@ -20,12 +23,12 @@ import seedu.weme.model.meme.Meme;
 public class MemeGridPanel extends UiPart<Region> {
     private static final String FXML = "MemeGridPanel.fxml";
     private final Logger logger = LogsCenter.getLogger(MemeGridPanel.class);
+    private final ObservableMap<String, SimpleIntegerProperty> likeData;
+    private final ObservableMap<String, SimpleIntegerProperty> dislikeData;
+    private final Map<ImagePath, MemeCard> memeCardMap = new HashMap<>();
 
     @FXML
     private GridView<Meme> memeGridView;
-
-    private ObservableMap<String, SimpleIntegerProperty> likeData;
-    private ObservableMap<String, SimpleIntegerProperty> dislikeData;
 
     public MemeGridPanel(ObservableList<Meme> memeList,
                          ObservableMap<String, SimpleIntegerProperty> likeData,
@@ -48,10 +51,19 @@ public class MemeGridPanel extends UiPart<Region> {
                 setGraphic(null);
                 setText(null);
             } else {
-                String filePath = meme.getImagePath().toString();
-                SimpleIntegerProperty likes = likeData.get(filePath);
-                SimpleIntegerProperty dislikes = dislikeData.get(filePath);
-                setGraphic(new MemeCard(meme, getIndex() + 1, likes, dislikes).getRoot());
+                // Cache the meme card to improve performance
+                ImagePath imagePath = meme.getImagePath();
+                MemeCard card = memeCardMap.get(imagePath);
+                int newIndex = getIndex() + 1;
+                SimpleIntegerProperty likes = likeData.get(imagePath.toString());
+                SimpleIntegerProperty dislikes = dislikeData.get(imagePath.toString());
+                if (card == null) {
+                    card = new MemeCard(meme, newIndex, likes, dislikes);
+                    memeCardMap.put(imagePath, card);
+                } else {
+                    card.update(meme, newIndex, likes, dislikes);
+                }
+                setGraphic(card.getRoot());
             }
         }
     }

--- a/src/main/java/seedu/weme/ui/TemplateCard.java
+++ b/src/main/java/seedu/weme/ui/TemplateCard.java
@@ -38,7 +38,7 @@ public class TemplateCard extends UiPart<Region> {
         super(FXML);
         this.template = template;
         id.setText(displayedIndex + "");
-        display.setImage(new Image(template.getImagePath().toUrl().toString(), 200, 200, true, true));
+        display.setImage(new Image(template.getImagePath().toUrl().toString(), 200, 200, true, true, true));
         name.setText(template.getName().toString());
     }
 

--- a/src/main/java/seedu/weme/ui/TemplateCard.java
+++ b/src/main/java/seedu/weme/ui/TemplateCard.java
@@ -38,7 +38,7 @@ public class TemplateCard extends UiPart<Region> {
         super(FXML);
         this.template = template;
         id.setText(displayedIndex + "");
-        display.setImage(new Image(template.getImagePath().toUrl().toString()));
+        display.setImage(new Image(template.getImagePath().toUrl().toString(), 200, 200, true, true));
         name.setText(template.getName().toString());
     }
 

--- a/src/main/java/seedu/weme/ui/TemplateCard.java
+++ b/src/main/java/seedu/weme/ui/TemplateCard.java
@@ -42,6 +42,16 @@ public class TemplateCard extends UiPart<Region> {
         name.setText(template.getName().toString());
     }
 
+    /**
+     * Updates the card content except for the template image.
+     * @param template the template this card is for
+     * @param newIndex the new index of the this card
+     */
+    public void update(Template template, int newIndex) {
+        id.setText(newIndex + "");
+        name.setText(template.getName().toString());
+    }
+
     @Override
     public boolean equals(Object other) {
         // short circuit if same object
@@ -57,6 +67,6 @@ public class TemplateCard extends UiPart<Region> {
         // state check
         TemplateCard card = (TemplateCard) other;
         return id.getText().equals(card.id.getText())
-            && template.equals(card.template);
+                && template.equals(card.template);
     }
 }

--- a/src/main/java/seedu/weme/ui/TemplateGridPanel.java
+++ b/src/main/java/seedu/weme/ui/TemplateGridPanel.java
@@ -1,11 +1,15 @@
 package seedu.weme.ui;
 
+import java.util.HashMap;
+import java.util.Map;
+
 import org.controlsfx.control.GridCell;
 import org.controlsfx.control.GridView;
 
 import javafx.collections.ObservableList;
 import javafx.fxml.FXML;
 import javafx.scene.layout.Region;
+import seedu.weme.model.imagePath.ImagePath;
 import seedu.weme.model.template.Template;
 
 /**
@@ -13,6 +17,7 @@ import seedu.weme.model.template.Template;
  */
 public class TemplateGridPanel extends UiPart<Region> {
     private static final String FXML = "TemplateGridPanel.fxml";
+    private final Map<ImagePath, TemplateCard> templateCardMap = new HashMap<>();
 
     @FXML
     private GridView<Template> templateGridView;
@@ -35,7 +40,16 @@ public class TemplateGridPanel extends UiPart<Region> {
                 setGraphic(null);
                 setText(null);
             } else {
-                setGraphic(new TemplateCard(template, getIndex() + 1).getRoot());
+                ImagePath imagePath = template.getImagePath();
+                TemplateCard card = templateCardMap.get(imagePath);
+                int newIndex = getIndex() + 1;
+                if (card == null) {
+                    card = new TemplateCard(template, newIndex);
+                    templateCardMap.put(imagePath, card);
+                } else {
+                    card.update(template, newIndex);
+                }
+                setGraphic(card.getRoot());
             }
         }
     }

--- a/src/main/resources/view/ImportMemeGridCard.fxml
+++ b/src/main/resources/view/ImportMemeGridCard.fxml
@@ -7,23 +7,23 @@
 <?import javafx.scene.layout.FlowPane?>
 <?import javafx.scene.layout.GridPane?>
 <?import javafx.scene.layout.HBox?>
-<?import javafx.scene.layout.Pane?>
-<?import javafx.scene.layout.RowConstraints?>
 <?import javafx.scene.layout.VBox?>
 
-<HBox fx:id="cardPane" xmlns="http://javafx.com/javafx/8" xmlns:fx="http://javafx.com/fxml/1">
-    <GridPane alignment="CENTER" HBox.hgrow="ALWAYS">
-        <columnConstraints>
-            <ColumnConstraints hgrow="SOMETIMES" minWidth="250" prefWidth="250" />
-        </columnConstraints>
-        <VBox alignment="CENTER" minWidth="250" spacing="5" GridPane.columnIndex="0">
-            <padding>
-                <Insets bottom="5" left="5" right="5" top="5" />
-            </padding>
-            <Label fx:id="id" styleClass="cell_big_label" />
-            <ImageView fx:id="display" cache="true" fitHeight="200" fitWidth="200" pickOnBounds="true" preserveRatio="true" />
-            <FlowPane fx:id="tags" alignment="CENTER" />
-            <Label fx:id="description" alignment="CENTER" contentDisplay="CENTER" styleClass="cell_small_label" text="\$description" />
-        </VBox>
-    </GridPane>
+<HBox xmlns:fx="http://javafx.com/fxml/1" fx:id="cardPane" xmlns="http://javafx.com/javafx/8">
+  <GridPane alignment="CENTER" HBox.hgrow="ALWAYS">
+    <columnConstraints>
+      <ColumnConstraints hgrow="SOMETIMES" minWidth="250" prefWidth="250"/>
+    </columnConstraints>
+    <VBox alignment="CENTER" minWidth="250" spacing="5" GridPane.columnIndex="0">
+      <padding>
+        <Insets bottom="5" left="5" right="5" top="5"/>
+      </padding>
+      <Label fx:id="id" styleClass="cell_big_label"/>
+      <ImageView fx:id="display" cache="true" cacheHint="SPEED" fitHeight="200" fitWidth="200" pickOnBounds="true"
+                 preserveRatio="true"/>
+      <FlowPane fx:id="tags" alignment="CENTER"/>
+      <Label fx:id="description" alignment="CENTER" contentDisplay="CENTER" styleClass="cell_small_label"
+             text="\$description"/>
+    </VBox>
+  </GridPane>
 </HBox>

--- a/src/main/resources/view/MemeGridCard.fxml
+++ b/src/main/resources/view/MemeGridCard.fxml
@@ -22,22 +22,22 @@
         <Insets bottom="5" left="5" right="5" top="5" />
       </padding>
       <Label fx:id="id" styleClass="cell_big_label" />
-      <ImageView fx:id="display" cache="true" fitHeight="200" fitWidth="200" pickOnBounds="true" preserveRatio="true" />
+      <ImageView fx:id="display" cache="true" cacheHint="SPEED" fitHeight="200" fitWidth="200" pickOnBounds="true" preserveRatio="true" />
       <FlowPane fx:id="tags" alignment="CENTER" />
       <Label fx:id="description" alignment="CENTER" contentDisplay="CENTER" styleClass="cell_small_label" text="\$description" />
         <Pane prefHeight="24.0" prefWidth="240.0">
           <children>
             <HBox alignment="CENTER_RIGHT" prefHeight="24.0" prefWidth="240.0">
               <children>
-                <ImageView fx:id="likeIcon" fitHeight="11.0" fitWidth="13.0" pickOnBounds="true" preserveRatio="true">
+                <ImageView fx:id="likeIcon" cache="true" cacheHint="SPEED" fitHeight="11.0" fitWidth="13.0" pickOnBounds="true" preserveRatio="true">
                   <image>
-                    <Image url="@../images/like_icon.png"/>
+                    <Image url="@../images/like_icon.png" smooth="true" requestedHeight="11.0" requestedWidth="13.0"/>
                   </image>
                 </ImageView>
                 <Label fx:id="likes" alignment="CENTER_RIGHT" contentDisplay="RIGHT" styleClass="cell_small_label" />
-                <ImageView fx:id="dislikeIcon" fitHeight="11.0" fitWidth="13.0" pickOnBounds="true" preserveRatio="true">
+                <ImageView fx:id="dislikeIcon" cache="true" cacheHint="SPEED" fitHeight="11.0" fitWidth="13.0" pickOnBounds="true" preserveRatio="true">
                   <image>
-                    <Image url="@../images/dislike_icon.png"/>
+                    <Image url="@../images/dislike_icon.png" smooth="true" requestedHeight="11.0" requestedWidth="13.0"/>
                   </image>
                 </ImageView>
                 <Label fx:id="dislikes" alignment="CENTER_RIGHT" contentDisplay="RIGHT" styleClass="cell_small_label" />

--- a/src/main/resources/view/TemplateGridCard.fxml
+++ b/src/main/resources/view/TemplateGridCard.fxml
@@ -18,7 +18,7 @@
         <Insets top="5" right="5" bottom="5" left="5"/>
       </padding>
       <Label fx:id="id" styleClass="cell_big_label"/>
-      <ImageView fx:id="display" fitHeight="200" fitWidth="200" cache="true" pickOnBounds="true" preserveRatio="true"/>
+      <ImageView fx:id="display" fitHeight="200" fitWidth="200" cache="true" cacheHint="SPEED" pickOnBounds="true" preserveRatio="true"/>
       <Label fx:id="name" styleClass="cell_big_label" text="\$name"/>
     </VBox>
   </GridPane>


### PR DESCRIPTION
Previously, a `MemeCard`/`TemplateCard`/`ImportMeme` card is created anew
whenever the `GridCell` is updated. This results in a lot of lagging and
explosive memory usage when scrolling because scrolling updates the `GridCell` and `MemeCard`/`TemplateCard`/`ImportMeme` reads
the image from the disk in their constructors. (Imagine if the user is using HDD)

With this commit, `MemeCard`/`TemplateCard`/`ImportMeme` are cached in their
parents and no repeated disk IO is made. Memory usage now is about 500MB
for ~500 memes and does not increase when scrolling.

The respective `GridViews` can scroll smoothly now. Tested with 1000 memes
and no significant lag is observed.

Demo: (the screen recorder was consuming a lot of resources, actual performance should be better than this)
![weme_no_lag](https://user-images.githubusercontent.com/44059321/68393689-80c85400-01a7-11ea-8015-42aaa9ba88f7.gif)
