### PR TITLE
Limit tags length

### DIFF
--- a/src/main/java/seedu/weme/model/tag/Tag.java
+++ b/src/main/java/seedu/weme/model/tag/Tag.java
@@ -11,6 +11,7 @@ public class Tag {
 
     public static final String MESSAGE_CONSTRAINTS = "Tags names should be alphanumeric and at most 35 characters.";
     public static final String VALIDATION_REGEX = "\\p{Alnum}+";
+    public static final int TAG_MAX_CHAR = 38;
 
     public final String tagName;
 
@@ -31,7 +32,7 @@ public class Tag {
      * <p>Limits the length of a tag name to 35 characters to avoid overflow.</p>
      */
     public static boolean isValidTagName(String test) {
-        return test.length() <= 35 && test.matches(VALIDATION_REGEX);
+        return test.length() <= TAG_MAX_CHAR && test.matches(VALIDATION_REGEX);
     }
 
     public String getTagName() {

--- a/src/main/java/seedu/weme/model/tag/Tag.java
+++ b/src/main/java/seedu/weme/model/tag/Tag.java
@@ -11,8 +11,8 @@ public class Tag {
 
     // This is measured so that with the longest tag and \"...\", the meme card will not overflow"
     public static final int TAG_MAX_CHAR = 30;
-    public static final String MESSAGE_CONSTRAINTS = "Tags names should be alphanumeric and at most " +
-            TAG_MAX_CHAR + " characters.";
+    public static final String MESSAGE_CONSTRAINTS = "Tags names should be alphanumeric and at most "
+            + TAG_MAX_CHAR + " characters.";
     public static final String VALIDATION_REGEX = "\\p{Alnum}+";
 
     public final String tagName;

--- a/src/main/java/seedu/weme/model/tag/Tag.java
+++ b/src/main/java/seedu/weme/model/tag/Tag.java
@@ -9,9 +9,11 @@ import static seedu.weme.commons.util.AppUtil.checkArgument;
  */
 public class Tag {
 
-    public static final String MESSAGE_CONSTRAINTS = "Tags names should be alphanumeric and at most 35 characters.";
+    // This is measured so that with the longest tag and \"...\", the meme card will not overflow"
+    public static final int TAG_MAX_CHAR = 30;
+    public static final String MESSAGE_CONSTRAINTS = "Tags names should be alphanumeric and at most " +
+            TAG_MAX_CHAR + " characters.";
     public static final String VALIDATION_REGEX = "\\p{Alnum}+";
-    public static final int TAG_MAX_CHAR = 38;
 
     public final String tagName;
 

--- a/src/main/java/seedu/weme/model/tag/Tag.java
+++ b/src/main/java/seedu/weme/model/tag/Tag.java
@@ -9,7 +9,7 @@ import static seedu.weme.commons.util.AppUtil.checkArgument;
  */
 public class Tag {
 
-    public static final String MESSAGE_CONSTRAINTS = "Tags names should be alphanumeric";
+    public static final String MESSAGE_CONSTRAINTS = "Tags names should be alphanumeric and at most 35 characters.";
     public static final String VALIDATION_REGEX = "\\p{Alnum}+";
 
     public final String tagName;
@@ -27,9 +27,11 @@ public class Tag {
 
     /**
      * Returns true if a given string is a valid tag name.
+     *
+     * <p>Limits the length of a tag name to 35 characters to avoid overflow.</p>
      */
     public static boolean isValidTagName(String test) {
-        return test.matches(VALIDATION_REGEX);
+        return test.length() <= 35 && test.matches(VALIDATION_REGEX);
     }
 
     public String getTagName() {

--- a/src/main/java/seedu/weme/ui/MemeCard.java
+++ b/src/main/java/seedu/weme/ui/MemeCard.java
@@ -1,16 +1,23 @@
 package seedu.weme.ui;
 
+import java.util.ArrayList;
 import java.util.Comparator;
+import java.util.HashSet;
+import java.util.List;
+import java.util.stream.Collectors;
 
 import javafx.beans.property.SimpleIntegerProperty;
 import javafx.fxml.FXML;
+import javafx.geometry.Orientation;
 import javafx.scene.control.Label;
 import javafx.scene.image.Image;
 import javafx.scene.image.ImageView;
+import javafx.scene.layout.AnchorPane;
 import javafx.scene.layout.FlowPane;
 import javafx.scene.layout.HBox;
 import javafx.scene.layout.Region;
 import seedu.weme.model.meme.Meme;
+import seedu.weme.model.tag.Tag;
 
 /**
  * An UI component that displays information of a {@code Meme}.
@@ -18,6 +25,8 @@ import seedu.weme.model.meme.Meme;
 public class MemeCard extends UiPart<Region> {
 
     private static final String FXML = "MemeGridCard.fxml";
+    private static final double TAGS_HEIGHT = 20.0;
+    private static final int TAGS_GAP_BY_CHAR = 2;
 
     /**
      * Note: Certain keywords such as "location" and "resources" are reserved keywords in JavaFX.
@@ -40,6 +49,8 @@ public class MemeCard extends UiPart<Region> {
     @FXML
     private FlowPane tags;
     @FXML
+    private HBox likeBox;
+    @FXML
     private Label likes;
     @FXML
     private Label dislikes;
@@ -51,10 +62,34 @@ public class MemeCard extends UiPart<Region> {
         super(FXML);
         this.meme = meme;
         id.setText(displayedIndex + "");
-        display.setImage(new Image(meme.getImagePath().toUrl().toString(), 200, 200, true, true, true));
+        Image image = new Image(meme.getImagePath().toUrl().toString(), 200, 200, true, true, true);
+        Image imageCopy = new Image(meme.getImagePath().toUrl().toString());
+        double height = imageCopy.getHeight();
+        double width = imageCopy.getWidth();
+        double aspectRatio = height / width;
+        double imageHeight = height > width ? 200 : aspectRatio * 200;
+        int rowsForTags = 1 + (int) Math.round(Math.floor((200 - imageHeight) / 20));
+        List<Integer> lengths = meme.getTags().stream()
+                .sorted(Comparator.comparing(tag -> tag.tagName))
+                .map(tag -> tag.getTagName().length())
+                .collect(Collectors.toCollection(ArrayList::new));
+        int limit = 0;
+        int numOfCharForTags = rowsForTags * 25;
+        int numOfCharInTagPane = 0;
+        for (int i = 0; i < meme.getTags().size(); i++) {
+            numOfCharInTagPane += lengths.get(i) + 2;
+            limit++;
+            if (numOfCharInTagPane > numOfCharForTags) {
+                break;
+            }
+        }
+        display.setImage(image);
         description.setText(meme.getDescription().value);
+        tags.orientationProperty().setValue(Orientation.HORIZONTAL);
+        tags.setMaxHeight(25 * rowsForTags );
         meme.getTags().stream()
                 .sorted(Comparator.comparing(tag -> tag.tagName))
+                .limit(limit)
                 .forEach(tag -> tags.getChildren().add(new Label(tag.tagName)));
         likes.setText(" " + numOfLikes.get() + " ");
         dislikes.setText(" " + numOfDislikes.get() + " ");
@@ -74,9 +109,33 @@ public class MemeCard extends UiPart<Region> {
         id.setText(newIndex + "");
         description.setText(meme.getDescription().value);
         tags.getChildren().clear();
+        Image imageCopy = new Image(meme.getImagePath().toUrl().toString());
+        double height = imageCopy.getHeight();
+        double width = imageCopy.getWidth();
+        double aspectRatio = height / width;
+        double imageHeight = height > width ? 200 : aspectRatio * 200;
+        int rowsForTags = 1 + (int) Math.round(Math.floor((200 - imageHeight) / 20));
+        List<Integer> lengths = meme.getTags().stream()
+                .sorted(Comparator.comparing(tag -> tag.tagName))
+                .map(tag -> tag.getTagName().length())
+                .collect(Collectors.toCollection(ArrayList::new));
+        int limit = 0;
+        int numOfCharForTags = rowsForTags * 25;
+        int numOfCharInTagPane = 0;
+        for (int i = 0; i < meme.getTags().size(); i++) {
+            numOfCharInTagPane += lengths.get(i) + 2;
+            limit++;
+            if (numOfCharInTagPane > numOfCharForTags) {
+                break;
+            }
+        }
         meme.getTags().stream()
                 .sorted(Comparator.comparing(tag -> tag.tagName))
+                .limit(limit)
                 .forEach(tag -> tags.getChildren().add(new Label(tag.tagName)));
+        if (limit < meme.getTags().size()) {
+            tags.getChildren().add(new Label(".."));
+        }
         likes.setText(" " + numOfLikes.get() + " ");
         dislikes.setText(" " + numOfDislikes.get() + " ");
         numOfLikes.addListener((observable, oldValue, newValue) ->

--- a/src/main/java/seedu/weme/ui/MemeCard.java
+++ b/src/main/java/seedu/weme/ui/MemeCard.java
@@ -26,7 +26,9 @@ public class MemeCard extends UiPart<Region> {
     private static final int IMAGE_MAX_WIDTH = 200;
     private static final int TAGS_HEIGHT = 25;
     private static final int TAGS_GAP_BY_CHAR = 2;
-    private static final int MAX_CHAR_PER_LINE = 38;
+    private static final int MAX_CHAR_PER_LINE = 35;
+    // a line can accommodate about 38 characters. In the case of a long string of tags followed by \"...\" case,
+    // we use 35 characters per line for display to prevent overflow.
 
     /**
      * Note: Certain keywords such as "location" and "resources" are reserved keywords in JavaFX.
@@ -137,11 +139,10 @@ public class MemeCard extends UiPart<Region> {
             numOfCharInCurrLine += lengths.get(i) + TAGS_GAP_BY_CHAR;
             limit++;
             if (numOfCharInCurrLine > MAX_CHAR_PER_LINE) {
-                row++;
+                if (++row > rowsForTags) {
+                    break;
+                }
                 numOfCharInCurrLine = 0;
-            }
-            if (row > rowsForTags) {
-                break;
             }
         }
         return limit;

--- a/src/main/java/seedu/weme/ui/MemeCard.java
+++ b/src/main/java/seedu/weme/ui/MemeCard.java
@@ -21,7 +21,7 @@ import seedu.weme.model.meme.Meme;
 public class MemeCard extends UiPart<Region> {
 
     private static final String FXML = "MemeGridCard.fxml";
-    private static final String TAG_TRUNCATE_TEXT = "..";
+    private static final String TAG_TRUNCATE_TEXT = "...";
     private static final int IMAGE_MAX_HEIGHT = 200;
     private static final int IMAGE_MAX_WIDTH = 200;
     private static final int TAGS_HEIGHT = 25;
@@ -98,7 +98,9 @@ public class MemeCard extends UiPart<Region> {
                 .limit(limit)
                 .forEach(tag -> tags.getChildren().add(new Label(tag.tagName)));
         if (limit < meme.getTags().size()) {
-            tags.getChildren().add(new Label(TAG_TRUNCATE_TEXT));
+            Label truncatedText = new Label(TAG_TRUNCATE_TEXT);
+            truncatedText.setStyle("-fx-background-color: transparent");
+            tags.getChildren().add(truncatedText);
         }
         likes.setText(" " + numOfLikes.get() + " ");
         dislikes.setText(" " + numOfDislikes.get() + " ");
@@ -108,6 +110,9 @@ public class MemeCard extends UiPart<Region> {
                 dislikes.setText(Integer.toString((int) newValue)));
     }
 
+    /**
+     * Returns the limit on the number of tags a meme card can contain such that there is no overflow of content.
+     */
     private int getTagLimit(Meme meme) {
         Image imageCopy = new Image(meme.getImagePath().toUrl().toString());
         int limit = 0;
@@ -118,7 +123,6 @@ public class MemeCard extends UiPart<Region> {
         double aspectRatio = height / width;
         double imageHeight = height > width ? IMAGE_MAX_HEIGHT : aspectRatio * IMAGE_MAX_HEIGHT;
         int rowsForTags = 1 + (int) Math.round(Math.floor((IMAGE_MAX_HEIGHT - imageHeight) / TAGS_HEIGHT));
-        int row = 1;
 
         // get the lengths of the tags for a meme.
         List<Integer> lengths = meme.getTags().stream()
@@ -128,6 +132,7 @@ public class MemeCard extends UiPart<Region> {
 
         // calculate the number of tags that can fit into the FlowPane.
         int numOfCharInCurrLine = 0;
+        int row = 1;
         for (int i = 0; i < meme.getTags().size(); i++) {
             numOfCharInCurrLine += lengths.get(i) + TAGS_GAP_BY_CHAR;
             limit++;

--- a/src/main/java/seedu/weme/ui/MemeCard.java
+++ b/src/main/java/seedu/weme/ui/MemeCard.java
@@ -2,22 +2,18 @@ package seedu.weme.ui;
 
 import java.util.ArrayList;
 import java.util.Comparator;
-import java.util.HashSet;
 import java.util.List;
 import java.util.stream.Collectors;
 
 import javafx.beans.property.SimpleIntegerProperty;
 import javafx.fxml.FXML;
-import javafx.geometry.Orientation;
 import javafx.scene.control.Label;
 import javafx.scene.image.Image;
 import javafx.scene.image.ImageView;
-import javafx.scene.layout.AnchorPane;
 import javafx.scene.layout.FlowPane;
 import javafx.scene.layout.HBox;
 import javafx.scene.layout.Region;
 import seedu.weme.model.meme.Meme;
-import seedu.weme.model.tag.Tag;
 
 /**
  * An UI component that displays information of a {@code Meme}.
@@ -25,8 +21,12 @@ import seedu.weme.model.tag.Tag;
 public class MemeCard extends UiPart<Region> {
 
     private static final String FXML = "MemeGridCard.fxml";
-    private static final double TAGS_HEIGHT = 20.0;
+    private static final String TAG_TRUNCATE_TEXT = "..";
+    private static final int IMAGE_MAX_HEIGHT = 200;
+    private static final int IMAGE_MAX_WIDTH = 200;
+    private static final int TAGS_HEIGHT = 25;
     private static final int TAGS_GAP_BY_CHAR = 2;
+    private static final int MAX_CHAR_PER_LINE = 38;
 
     /**
      * Note: Certain keywords such as "location" and "resources" are reserved keywords in JavaFX.
@@ -62,35 +62,18 @@ public class MemeCard extends UiPart<Region> {
         super(FXML);
         this.meme = meme;
         id.setText(displayedIndex + "");
-        Image image = new Image(meme.getImagePath().toUrl().toString(), 200, 200, true, true, true);
-        Image imageCopy = new Image(meme.getImagePath().toUrl().toString());
-        double height = imageCopy.getHeight();
-        double width = imageCopy.getWidth();
-        double aspectRatio = height / width;
-        double imageHeight = height > width ? 200 : aspectRatio * 200;
-        int rowsForTags = 1 + (int) Math.round(Math.floor((200 - imageHeight) / 20));
-        List<Integer> lengths = meme.getTags().stream()
-                .sorted(Comparator.comparing(tag -> tag.tagName))
-                .map(tag -> tag.getTagName().length())
-                .collect(Collectors.toCollection(ArrayList::new));
-        int limit = 0;
-        int numOfCharForTags = rowsForTags * 25;
-        int numOfCharInTagPane = 0;
-        for (int i = 0; i < meme.getTags().size(); i++) {
-            numOfCharInTagPane += lengths.get(i) + 2;
-            limit++;
-            if (numOfCharInTagPane > numOfCharForTags) {
-                break;
-            }
-        }
+        Image image = new Image(meme.getImagePath().toUrl().toString(), IMAGE_MAX_WIDTH, IMAGE_MAX_HEIGHT,
+                true, true, true);
+        int limit = getTagLimit(meme);
         display.setImage(image);
         description.setText(meme.getDescription().value);
-        tags.orientationProperty().setValue(Orientation.HORIZONTAL);
-        tags.setMaxHeight(25 * rowsForTags );
         meme.getTags().stream()
                 .sorted(Comparator.comparing(tag -> tag.tagName))
                 .limit(limit)
                 .forEach(tag -> tags.getChildren().add(new Label(tag.tagName)));
+        if (limit < meme.getTags().size()) {
+            tags.getChildren().add(new Label(TAG_TRUNCATE_TEXT));
+        }
         likes.setText(" " + numOfLikes.get() + " ");
         dislikes.setText(" " + numOfDislikes.get() + " ");
         numOfLikes.addListener((observable, oldValue, newValue) ->
@@ -109,32 +92,13 @@ public class MemeCard extends UiPart<Region> {
         id.setText(newIndex + "");
         description.setText(meme.getDescription().value);
         tags.getChildren().clear();
-        Image imageCopy = new Image(meme.getImagePath().toUrl().toString());
-        double height = imageCopy.getHeight();
-        double width = imageCopy.getWidth();
-        double aspectRatio = height / width;
-        double imageHeight = height > width ? 200 : aspectRatio * 200;
-        int rowsForTags = 1 + (int) Math.round(Math.floor((200 - imageHeight) / 20));
-        List<Integer> lengths = meme.getTags().stream()
-                .sorted(Comparator.comparing(tag -> tag.tagName))
-                .map(tag -> tag.getTagName().length())
-                .collect(Collectors.toCollection(ArrayList::new));
-        int limit = 0;
-        int numOfCharForTags = rowsForTags * 25;
-        int numOfCharInTagPane = 0;
-        for (int i = 0; i < meme.getTags().size(); i++) {
-            numOfCharInTagPane += lengths.get(i) + 2;
-            limit++;
-            if (numOfCharInTagPane > numOfCharForTags) {
-                break;
-            }
-        }
+        int limit = getTagLimit(meme);
         meme.getTags().stream()
                 .sorted(Comparator.comparing(tag -> tag.tagName))
                 .limit(limit)
                 .forEach(tag -> tags.getChildren().add(new Label(tag.tagName)));
         if (limit < meme.getTags().size()) {
-            tags.getChildren().add(new Label(".."));
+            tags.getChildren().add(new Label(TAG_TRUNCATE_TEXT));
         }
         likes.setText(" " + numOfLikes.get() + " ");
         dislikes.setText(" " + numOfDislikes.get() + " ");
@@ -142,6 +106,40 @@ public class MemeCard extends UiPart<Region> {
                 likes.setText(Integer.toString((int) newValue)));
         numOfDislikes.addListener((observable, oldValue, newValue) ->
                 dislikes.setText(Integer.toString((int) newValue)));
+    }
+
+    private int getTagLimit(Meme meme) {
+        Image imageCopy = new Image(meme.getImagePath().toUrl().toString());
+        int limit = 0;
+
+        // get the number of rows for tag display.
+        double height = imageCopy.getHeight();
+        double width = imageCopy.getWidth();
+        double aspectRatio = height / width;
+        double imageHeight = height > width ? IMAGE_MAX_HEIGHT : aspectRatio * IMAGE_MAX_HEIGHT;
+        int rowsForTags = 1 + (int) Math.round(Math.floor((IMAGE_MAX_HEIGHT - imageHeight) / TAGS_HEIGHT));
+        int row = 1;
+
+        // get the lengths of the tags for a meme.
+        List<Integer> lengths = meme.getTags().stream()
+                .sorted(Comparator.comparing(tag -> tag.tagName))
+                .map(tag -> tag.getTagName().length())
+                .collect(Collectors.toCollection(ArrayList::new));
+
+        // calculate the number of tags that can fit into the FlowPane.
+        int numOfCharInCurrLine = 0;
+        for (int i = 0; i < meme.getTags().size(); i++) {
+            numOfCharInCurrLine += lengths.get(i) + TAGS_GAP_BY_CHAR;
+            limit++;
+            if (numOfCharInCurrLine > MAX_CHAR_PER_LINE) {
+                row++;
+                numOfCharInCurrLine = 0;
+            }
+            if (row > rowsForTags) {
+                break;
+            }
+        }
+        return limit;
     }
 
     @Override

--- a/src/main/resources/view/MemeGridCard.fxml
+++ b/src/main/resources/view/MemeGridCard.fxml
@@ -12,7 +12,7 @@
 <?import javafx.scene.layout.RowConstraints?>
 <?import javafx.scene.layout.VBox?>
 
-<HBox fx:id="cardPane" xmlns="http://javafx.com/javafx/11.0.1" xmlns:fx="http://javafx.com/fxml/1">
+<HBox fx:id="cardPane" xmlns="http://javafx.com/javafx/8" xmlns:fx="http://javafx.com/fxml/1">
   <GridPane alignment="CENTER" HBox.hgrow="ALWAYS">
     <columnConstraints>
       <ColumnConstraints hgrow="SOMETIMES" minWidth="250" prefWidth="250" />
@@ -22,12 +22,9 @@
         <Insets bottom="5" left="5" right="5" top="5" />
       </padding>
       <Label fx:id="id" styleClass="cell_big_label" />
-        <VBox alignment="CENTER" prefHeight="400.0" prefWidth="100.0">
+        <VBox alignment="CENTER" prefHeight="400.0" spacing="5" prefWidth="100.0">
             <ImageView fx:id="display" cache="true" cacheHint="SPEED" fitHeight="200" fitWidth="200" pickOnBounds="true"
                        preserveRatio="true"/>
-            <padding>
-              <Insets bottom="5" left="5" right="5" top="5"/>
-            </padding>
             <FlowPane fx:id="tags" alignment="CENTER" maxHeight="50" maxWidth="${cardPane.width}"/>
             <Label fx:id="description" alignment="CENTER" contentDisplay="CENTER" styleClass="cell_small_label"
                    text="\$description"/>

--- a/src/main/resources/view/MemeGridCard.fxml
+++ b/src/main/resources/view/MemeGridCard.fxml
@@ -2,17 +2,17 @@
 
 <?import javafx.geometry.Insets?>
 <?import javafx.scene.control.Label?>
+<?import javafx.scene.image.Image?>
 <?import javafx.scene.image.ImageView?>
+<?import javafx.scene.layout.AnchorPane?>
 <?import javafx.scene.layout.ColumnConstraints?>
 <?import javafx.scene.layout.FlowPane?>
 <?import javafx.scene.layout.GridPane?>
 <?import javafx.scene.layout.HBox?>
-<?import javafx.scene.layout.Pane?>
 <?import javafx.scene.layout.RowConstraints?>
 <?import javafx.scene.layout.VBox?>
 
-<?import javafx.scene.image.Image?>
-<HBox fx:id="cardPane" xmlns="http://javafx.com/javafx/8" xmlns:fx="http://javafx.com/fxml/1">
+<HBox fx:id="cardPane" xmlns="http://javafx.com/javafx/11.0.1" xmlns:fx="http://javafx.com/fxml/1">
   <GridPane alignment="CENTER" HBox.hgrow="ALWAYS">
     <columnConstraints>
       <ColumnConstraints hgrow="SOMETIMES" minWidth="250" prefWidth="250" />
@@ -22,29 +22,30 @@
         <Insets bottom="5" left="5" right="5" top="5" />
       </padding>
       <Label fx:id="id" styleClass="cell_big_label" />
-      <ImageView fx:id="display" cache="true" cacheHint="SPEED" fitHeight="200" fitWidth="200" pickOnBounds="true" preserveRatio="true" />
-      <FlowPane fx:id="tags" alignment="CENTER" />
-      <Label fx:id="description" alignment="CENTER" contentDisplay="CENTER" styleClass="cell_small_label" text="\$description" />
-        <Pane prefHeight="24.0" prefWidth="240.0">
-          <children>
-            <HBox alignment="CENTER_RIGHT" prefHeight="24.0" prefWidth="240.0">
-              <children>
-                <ImageView fx:id="likeIcon" cache="true" cacheHint="SPEED" fitHeight="11.0" fitWidth="13.0" pickOnBounds="true" preserveRatio="true">
-                  <image>
-                    <Image url="@../images/like_icon.png" smooth="true" requestedHeight="11.0" requestedWidth="13.0"/>
-                  </image>
-                </ImageView>
-                <Label fx:id="likes" alignment="CENTER_RIGHT" contentDisplay="RIGHT" styleClass="cell_small_label" />
-                <ImageView fx:id="dislikeIcon" cache="true" cacheHint="SPEED" fitHeight="11.0" fitWidth="13.0" pickOnBounds="true" preserveRatio="true">
-                  <image>
-                    <Image url="@../images/dislike_icon.png" smooth="true" requestedHeight="11.0" requestedWidth="13.0"/>
-                  </image>
-                </ImageView>
-                <Label fx:id="dislikes" alignment="CENTER_RIGHT" contentDisplay="RIGHT" styleClass="cell_small_label" />
-              </children>
-            </HBox>
-          </children>
-         </Pane>
+        <VBox alignment="CENTER" prefHeight="400.0" prefWidth="100.0">
+            <ImageView fx:id="display" cache="true" cacheHint="SPEED" fitHeight="200" fitWidth="200" pickOnBounds="true"
+                       preserveRatio="true"/>
+            <padding>
+              <Insets bottom="5" left="5" right="5" top="5"/>
+            </padding>
+            <FlowPane fx:id="tags" alignment="CENTER" maxHeight="50" maxWidth="${cardPane.width}"/>
+            <Label fx:id="description" alignment="CENTER" contentDisplay="CENTER" styleClass="cell_small_label"
+                   text="\$description"/>
+        </VBox>
+         <AnchorPane fx:id="likeAnchor" prefHeight="23.0" prefWidth="240.0">
+            <children>
+           <HBox alignment="CENTER_RIGHT" prefHeight="24.0" prefWidth="240.0">
+             <ImageView fx:id="likeIcon" cache="true" cacheHint="SPEED" fitHeight="11.0" fitWidth="13.0" pickOnBounds="true" preserveRatio="true">
+               <Image requestedHeight="11.0" requestedWidth="13.0" smooth="true" url="@../images/like_icon.png" />
+             </ImageView>
+             <Label fx:id="likes" alignment="CENTER_RIGHT" contentDisplay="RIGHT" styleClass="cell_small_label" />
+             <ImageView fx:id="dislikeIcon" cache="true" cacheHint="SPEED" fitHeight="11.0" fitWidth="13.0" pickOnBounds="true" preserveRatio="true">
+               <Image requestedHeight="11.0" requestedWidth="13.0" smooth="true" url="@../images/dislike_icon.png" />
+             </ImageView>
+             <Label fx:id="dislikes" alignment="CENTER_RIGHT" contentDisplay="RIGHT" styleClass="cell_small_label" />
+           </HBox>
+            </children>
+         </AnchorPane>
     </VBox>
       <rowConstraints>
          <RowConstraints />


### PR DESCRIPTION
closes #243 Tag length issue
Limit length of tag name to 38 characters (about the same width as a MemeCard). Limit number of tags display in MemeCard in Memes panel. If there are undisplayed tags, display ".." as a placeholder. This is to prevent tag overflow.
Closes #175 