### PR TITLE
Size meme image in view Panel

### DIFF
--- a/src/main/java/seedu/weme/ui/ViewPanel.java
+++ b/src/main/java/seedu/weme/ui/ViewPanel.java
@@ -36,9 +36,7 @@ public class ViewPanel extends UiPart<Region> {
     public ViewPanel(ObservableValue<Meme> observableMeme) {
         super(FXML);
         observableMeme.addListener((observable, oldValue, newValue) -> {
-            display.setImage(new Image(newValue.getImagePath().toUrl().toString(),
-                    400, 400,
-                    true, true, true));
+            display.setImage(new Image(newValue.getImagePath().toUrl().toString()));
             description.setText(newValue.getDescription().value);
             tags.getChildren().clear();
             newValue.getTags().stream()

--- a/src/main/resources/view/ViewPanel.fxml
+++ b/src/main/resources/view/ViewPanel.fxml
@@ -11,7 +11,7 @@
 <?import javafx.scene.control.ScrollPane?>
 <?import javafx.scene.layout.AnchorPane?>
 <HBox xmlns:fx="http://javafx.com/fxml/1" fx:id="cardPane" xmlns="http://javafx.com/javafx/8">
-    <ScrollPane fx:id="scroll" hbarPolicy="NEVER" minWidth="250" prefWidth="500" HBox.hgrow="ALWAYS">
+    <ScrollPane fx:id="scroll" hbarPolicy="NEVER" minWidth="250" prefWidth="500" HBox.hgrow="ALWAYS" styleClass="pane-with-border">
         <AnchorPane>
             <StackPane fx:id="stackPane" alignment="CENTER" HBox.hgrow="ALWAYS" minHeight="${scroll.height}" styleClass="pane-with-border">
                 <VBox alignment="CENTER" minWidth="${scroll.width}" spacing="5" >

--- a/src/main/resources/view/ViewPanel.fxml
+++ b/src/main/resources/view/ViewPanel.fxml
@@ -3,24 +3,29 @@
 <?import javafx.geometry.Insets?>
 <?import javafx.scene.image.ImageView?>
 <?import javafx.scene.layout.HBox?>
-<?import javafx.scene.layout.GridPane?>
 <?import javafx.scene.layout.VBox?>
 <?import javafx.scene.control.Label?>
 <?import javafx.scene.layout.FlowPane?>
 
 <?import javafx.scene.layout.StackPane?>
+<?import javafx.scene.control.ScrollPane?>
+<?import javafx.scene.layout.AnchorPane?>
 <HBox xmlns:fx="http://javafx.com/fxml/1" fx:id="cardPane" xmlns="http://javafx.com/javafx/8">
-    <StackPane fx:id="stackPane" alignment="CENTER" HBox.hgrow="ALWAYS">
-        <VBox alignment="CENTER" minWidth="250" spacing="5" GridPane.columnIndex="0">
-            <padding>
-                <Insets bottom="5" left="5" right="5" top="5"/>
-            </padding>
-            <Label fx:id="id" styleClass="cell_big_label"/>
-            <ImageView fx:id="display" cache="true" cacheHint="SPEED" fitHeight="400" fitWidth="400" pickOnBounds="true"
-                       preserveRatio="true"/>
-            <FlowPane fx:id="tags" alignment="CENTER"/>
-            <Label fx:id="description" alignment="CENTER" contentDisplay="CENTER" styleClass="cell_view_label"
-                   text="\$description"/>
-        </VBox>
-    </StackPane>
+    <ScrollPane fx:id="scroll" hbarPolicy="NEVER" minWidth="250" prefWidth="500" HBox.hgrow="ALWAYS">
+        <AnchorPane>
+            <StackPane fx:id="stackPane" alignment="CENTER" HBox.hgrow="ALWAYS" minHeight="${scroll.height}" styleClass="pane-with-border">
+                <VBox alignment="CENTER" minWidth="${scroll.width}" spacing="5" >
+                    <padding>
+                        <Insets bottom="5" left="5" right="5" top="5"/>
+                    </padding>
+                    <Label fx:id="id" styleClass="cell_big_label"/>
+                    <ImageView fx:id="display" cache="true" cacheHint="SPEED" fitWidth="400" pickOnBounds="true"
+                               preserveRatio="true"/>
+                    <FlowPane fx:id="tags" alignment="CENTER"/>
+                    <Label fx:id="description" alignment="CENTER" contentDisplay="CENTER" styleClass="cell_view_label"
+                           text="\$description"/>
+                </VBox>
+            </StackPane>
+        </AnchorPane>
+    </ScrollPane>
 </HBox>


### PR DESCRIPTION
Size the meme image in view panel such that long meme (vertical) can be viewed through scrolling (pending scroll feature).
Usually we would only encounter vertical long meme but not horizontal one, hence the change to limit width only for better UX.