### PR TITLE
Set limit to stats data display

### DIFF
--- a/src/main/java/seedu/weme/model/statistics/TagManager.java
+++ b/src/main/java/seedu/weme/model/statistics/TagManager.java
@@ -128,6 +128,7 @@ public class TagManager {
         }
 
         Collections.sort(tagsWithLike);
+        Collections.sort(tagsWithDislike);
     }
 
 }

--- a/src/main/java/seedu/weme/ui/StatsPanel.java
+++ b/src/main/java/seedu/weme/ui/StatsPanel.java
@@ -93,6 +93,7 @@ public class StatsPanel extends UiPart<Region> {
             data.add(new PieChart.Data(tag.getTag().tagName, tag.getData()));
         }
         ObservableList<PieChart.Data> pieChartData = data.stream()
+                .limit(10)
                 .map(this::bindValueToLabel)
                 .collect(Collectors.toCollection(FXCollections::observableArrayList));
         chart.setData(pieChartData);


### PR DESCRIPTION
Limit the number of data points in pie charts to 10 for proper display.